### PR TITLE
Support for data in login response

### DIFF
--- a/src/message/message-builder.js
+++ b/src/message/message-builder.js
@@ -2,7 +2,7 @@ var C = require( '../constants/constants' ),
 	SEP = C.MESSAGE_PART_SEPERATOR;
 
 /**
- * Creates a deepstream message string, based on the 
+ * Creates a deepstream message string, based on the
  * provided parameters
  *
  * @param   {String} topic  One of CONSTANTS.TOPIC
@@ -34,7 +34,7 @@ exports.getMsg = function( topic, action, data ) {
  *
  * @param   {String} topic   One of CONSTANTS.TOPIC - error messages might either be send on
  *                           the generic ERROR topic or on the topic that caused the error
- *                           
+ *
  * @param   {String} type    One of CONSTANTS.EVENT
  * @param   {String | Array } message a message text or an array of data
  *
@@ -52,44 +52,44 @@ exports.getErrorMsg = function( topic, type, message ) {
 /**
  * Converts a serializable value into its string-representation and adds
  * a flag that provides instructions on how to deserialize it.
- * 
+ *
  * Please see messageParser.convertTyped for the counterpart of this method
- * 
+ *
  * @param {Mixed} value
- * 
+ *
  * @public
  * @returns {String} string representation of the value
  */
 exports.typed = function( value ) {
 	var type = typeof value;
-	
+
 	if( type === 'string' ) {
 		return C.TYPES.STRING + value;
 	}
-	
+
 	if( value === null ) {
 		return C.TYPES.NULL;
 	}
-	
+
 	if( type === 'object' ) {
 		return C.TYPES.OBJECT + JSON.stringify( value );
 	}
-	
+
 	if( type === 'number' ) {
 		return C.TYPES.NUMBER + value.toString();
 	}
-	
+
 	if( value === true ) {
 		return C.TYPES.TRUE;
 	}
-	
+
 	if( value === false ) {
 		return C.TYPES.FALSE;
 	}
-	
+
 	if( value === undefined ) {
 		return C.TYPES.UNDEFINED;
 	}
-	
+
 	throw new Error( 'Can\'t serialize type ' + value );
 };

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -227,7 +227,7 @@ describe( 'connection endpoint', function() {
 
 			socketMock.emit( 'message', _msg( 'A|REQ|{"user":"wolfram"}+' ) );
 
-			expect( socketMock.lastSendMessage ).toBe( _msg( 'A|A+' ) );
+			expect( socketMock.lastSendMessage ).toBe( _msg( 'A|A|test-data+' ) );
 			expect( socketMock.isDisconnected ).toBe( false );
 		});
 
@@ -252,7 +252,7 @@ describe( 'connection endpoint', function() {
 			connectionEndpoint.close();
 
 			setTimeout( function() {
-				expect( closeSpy ).toHaveBeenCalled();	
+				expect( closeSpy ).toHaveBeenCalled();
 				done();
 			}, 0 );
 		} );

--- a/test/mocks/permission-handler-mock.js
+++ b/test/mocks/permission-handler-mock.js
@@ -9,7 +9,7 @@ var PermissionHandlerMock = function() {
 PermissionHandlerMock.prototype.isValidUser = function( handshakeData, authData, callback ) {
 	this.lastUserValidationQueryArgs = arguments;
 	if( this.nextUserValidationResult === true ) {
-		callback( null, 'test-user' );
+		callback( null, 'test-user', 'test-data' );
 	} else {
 		callback( 'Invalid User' );
 	}


### PR DESCRIPTION
This adds support for data in login response, e.g:
```javascript
server.set('permissionHandler', {
  isValidUser: function(connectionData, authData, callback) {
    callback(null, authData.username, { property: 'value' })
  }
})
```

Fixes #88