### PR TITLE
Allow for passing in an existing HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# IDE configuration
+.idea

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -19,6 +19,8 @@ exports.get = function() {
 		host: argv.host || '0.0.0.0',
 		tcpPort: argv.tcpPort || 6021,
 		tcpHost: argv.tcpHost || '0.0.0.0',
+		httpServer: null,
+		urlPath: '/engine.io',
 
 		/*
 		 * SSL Configuration

--- a/src/message/connection-endpoint.js
+++ b/src/message/connection-endpoint.js
@@ -34,6 +34,11 @@ var ConnectionEndpoint = function( options, readyCallback ) {
 
 	if ( this._options.httpServer ) {
 		this._server = this._options.httpServer;
+		if ( this._server.listening ) {
+			this._checkReady.call( this, ENGINE_IO );
+		} else {
+			this._server.once( 'listening', this._checkReady.bind( this, ENGINE_IO ) );
+		}
 	} else {
 		if( this._isHttpsServer() ) {
 			var httpsOptions = {

--- a/src/message/connection-endpoint.js
+++ b/src/message/connection-endpoint.js
@@ -345,7 +345,7 @@ ConnectionEndpoint.prototype._checkReady = function( endpoint ) {
 
 	this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, msg );
 
-	if( this._tcpEndpointReady === true && this._engineIoReady === true ) {
+	if( this._readyCallback && this._tcpEndpointReady === true && this._engineIoReady === true ) {
 		this._readyCallback();
 	}
 };

--- a/src/message/connection-endpoint.js
+++ b/src/message/connection-endpoint.js
@@ -333,7 +333,8 @@ ConnectionEndpoint.prototype._checkReady = function( endpoint ) {
 	var msg;
 
 	if( endpoint === ENGINE_IO ) {
-		msg = 'Listening for browser connections on ' + this._options.host + ':' + this._options.port;
+		var address = this._server.address();
+		msg = 'Listening for browser connections on ' + address.address + ':' + address.port;
 		this._engineIoReady = true;
 	}
 

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -270,4 +270,51 @@ describe( 'connection endpoint', function() {
 		} );
 
 	});
+
+	describe( 'when using an existing HTTP server', function(){
+
+		it ( 'does not create an additional HTTP server', function() {
+			var options = {
+				'httpServer': httpMock.createServer(),
+				permissionHandler: require( '../mocks/permission-handler-mock' ),
+				logger: { log: function( logLevel, event, msg ){} }
+			};
+
+			spyOn(httpMock, 'createServer');
+			var endpoint = new ConnectionEndpoint(options);
+			expect( httpMock.createServer ).not.toHaveBeenCalled();
+		});
+
+		it ( 'ready callback is called if server is already listening', function(done) {
+			var server = httpMock.createServer();
+			var options = {
+				httpServer: server,
+				permissionHandler: require( '../mocks/permission-handler-mock' ),
+				logger: { log: function( logLevel, event, msg ){} }
+			};
+			server.listen( 3000, '0.0.0.0' );
+
+			var endpoint = new ConnectionEndpoint(options, function() {
+				done();
+			});
+		});
+
+		it ( 'ready callback is called if server starts listening after endpoint creation', function(done) {
+			var server = httpMock.createServer();
+			var options = {
+				httpServer: server,
+				permissionHandler: require( '../mocks/permission-handler-mock' ),
+				logger: { log: function( logLevel, event, msg ){} }
+			};
+
+			var endpoint = new ConnectionEndpoint(options, function() {
+				done();
+			});
+
+			setTimeout(function () {
+				server.listen( 3000, '0.0.0.0' );
+			}, 50);
+		});
+
+	});
 });

--- a/test/mocks/http-mock.js
+++ b/test/mocks/http-mock.js
@@ -1,10 +1,39 @@
-var HttpMock = function(){};
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
 
-HttpMock.prototype.createServer = function() {
+var HttpServerMock = function() {
+	EventEmitter.call(this);
+	this.listening = false;
+};
+
+HttpServerMock.prototype.listen = function ( port, host, callback ) {
+	this._port = port;
+	this._host = host;
+	var server = this;
+	process.nextTick( function() {
+		server.listening = true;
+		server.emit('listening');
+		callback && callback();
+	});
+};
+
+HttpServerMock.prototype.close = function( callback ) {
+	this.emit('close');
+	callback && callback();
+};
+
+HttpServerMock.prototype.address = function() {
 	return {
-		listen: function() {},
-		close: function( callback ) {  callback && callback(); }
-	}
+		address: this._host,
+		port: this._port
+	};
+};
+
+util.inherits(HttpServerMock, EventEmitter);
+
+var HttpMock = function(){};
+HttpMock.prototype.createServer = function() {
+	return new HttpServerMock();
 };
 
 module.exports = HttpMock;


### PR DESCRIPTION
Implements https://github.com/deepstreamIO/deepstream.io/issues/87 and the server component of https://github.com/deepstreamIO/deepstream.io-client-js/issues/63