### PR TITLE
Fixing changes to API changes in 6.0

### DIFF
--- a/test/message/connection-endpoint-disablingserversSpec.js
+++ b/test/message/connection-endpoint-disablingserversSpec.js
@@ -13,7 +13,9 @@ var proxyquire = require( 'proxyquire' ).noCallThru(),
 
 var otherOptions = {
 	permissionHandler: require( '../mocks/permission-handler-mock' ),
-	logger: { log: function( logLevel, event, msg ){} }
+	logger: { log: function( logLevel, event, msg ){} },
+	tcpPort: 6031,
+	tcpHost: 'localhost'
 };
 
 describe( 'disabling tcp or webserver endpoints', function() {

--- a/test/message/connection-endpoint-httpsSpec.js
+++ b/test/message/connection-endpoint-httpsSpec.js
@@ -18,7 +18,7 @@ options = {
 	logger: { log: function( logLevel, event, msg ){ lastLoggedMessage = msg; } },
 	maxAuthAttempts: 3,
 	logInvalidAuthData: true,
-	tcpServerEnabled: true,
+	tcpServerEnabled: false,
 	webServerEnabled: true
 };
 
@@ -32,7 +32,7 @@ describe( 'validates HTTPS server conditions', function() {
 		sslOptions = {
 			permissionHandler: require( '../mocks/permission-handler-mock' ),
 			logger: { log: function( logLevel, event, msg ){} },
-			tcpServerEnabled: true,
+			tcpServerEnabled: false,
 			webServerEnabled: true
 		};
 

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -17,7 +17,7 @@ options = {
 	logger: { log: function( logLevel, event, msg ){ lastLoggedMessage = msg; } },
 	maxAuthAttempts: 3,
 	logInvalidAuthData: true,
-	tcpServerEnabled: true,
+	tcpServerEnabled: false,
 	webServerEnabled: true
 };
 
@@ -208,6 +208,7 @@ describe( 'connection endpoint', function() {
 
 		it ( 'does not create an additional HTTP server', function() {
 			var options = {
+				tcpServerEnabled: false,
 				webServerEnabled: true,
 				'httpServer': httpMock.createServer(),
 				permissionHandler: require( '../mocks/permission-handler-mock' ),
@@ -222,6 +223,7 @@ describe( 'connection endpoint', function() {
 		it ( 'ready callback is called if server is already listening', function(done) {
 			var server = httpMock.createServer();
 			var options = {
+				tcpServerEnabled: false,
 				webServerEnabled: true,
 				httpServer: server,
 				permissionHandler: require( '../mocks/permission-handler-mock' ),

--- a/test/record/record-transitionSpec.js
+++ b/test/record/record-transitionSpec.js
@@ -261,6 +261,6 @@ describe( 'handles invalid message data', function(){
 	});
 
 	it( 'receives an error', function(){
-		expect( socketWrapper.socket.lastSendMessage ).toBe( msg( 'R|E|INVALID_MESSAGE_DATA|SyntaxError: Unexpected end of input:O{"invalid":"json+') );
+		expect( socketWrapper.socket.lastSendMessage ).toContain( msg( 'R|E|INVALID_MESSAGE_DATA|SyntaxError' ) );
 	});
 });


### PR DESCRIPTION
Tests are failing due to travis now running against 6.0

TCP Servers now have to take a port ( which makes sense ) but the tests don't close the server off properly. Given they are unit tests AND don't touch the TCP server ( all done via simulated connections or just http server tests ) i disabled the tcp server from being started ( via the deepstream option ).