### PR TITLE
Made server.set() return itself

### DIFF
--- a/src/deepstream.io.js
+++ b/src/deepstream.io.js
@@ -91,6 +91,7 @@ Deepstream.prototype.set = function( key, value ) {
 	}
 
 	this._options[ key ] = value;
+	return this;
 };
 
 /**


### PR DESCRIPTION
Allows for a user to do one line configuration:
server.set('host', 'localhost').set('port', '6020');