### PR TITLE
AuthenticationHandler not plugin, dependency plugins don't specifiy t…

### DIFF
--- a/src/authentication/open-authentication-handler.js
+++ b/src/authentication/open-authentication-handler.js
@@ -1,4 +1,5 @@
 'use strict';
+const EventEmitter = require( 'events' ).EventEmitter;
 
 /**
  * Used for users that don't provide a username
@@ -14,12 +15,13 @@ const OPEN = 'open';
  *
  * @class OpenAuthenticationHandler
  */
-module.exports = class OpenAuthenticationHandler{
+module.exports = class OpenAuthenticationHandler extends EventEmitter{
 	/**
 	 * @param {String} type exposes the type for logging purposes. This one is called
 	 *                      none to avoid confusion with openAuth
 	 */
 	constructor() {
+		super();
 		this.type = 'none';
 		this.isReady = true;
 	}

--- a/src/deepstream.io.js
+++ b/src/deepstream.io.js
@@ -50,7 +50,8 @@ var Deepstream = function( config ) {
 		'messageConnector',
 		'storage',
 		'cache',
-		'permissionHandler' //TODO: This now requires the permissionHandler to have a ready flag / emit events
+		'authenticationHandler',
+		'permissionHandler'
 	];
 
 };
@@ -152,11 +153,8 @@ Deepstream.prototype._start = function() {
 	}
 
 	if( global.deepstreamLibDir ) {
-                this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, 'library directory set to: ' + global.deepstreamLibDir );
+		this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, 'library directory set to: ' + global.deepstreamLibDir );
 	}
-
-	var authTypeMsg = 'authentication type ' + ( this._options.authenticationHandler.type || 'custom' );
-	this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, authTypeMsg );
 
 	if( this._options.dataTransforms && this._options.dataTransforms instanceof Array ) {
 		this._options.dataTransforms = new DataTransforms( this._options.dataTransforms );

--- a/src/permission/open-permission-handler.js
+++ b/src/permission/open-permission-handler.js
@@ -1,16 +1,19 @@
 'use strict';
 
+const EventEmitter = require( 'events' ).EventEmitter;
+
 /**
  * The open permission handler allows any action to occur without applying
  * any permissions.
  *
  * @class OpenPermissionHandler
  */
-module.exports = class OpenPermissionHandler{
+module.exports = class OpenPermissionHandler extends EventEmitter{
 	/**
 	 * @param {String} type exposes the type for logging purposes
 	 */
 	constructor() {
+		super();
 		this.type = 'none';
 		this.isReady = true;
 	}

--- a/src/utils/dependency-initialiser.js
+++ b/src/utils/dependency-initialiser.js
@@ -56,7 +56,8 @@ DependencyInitialiser.prototype._onReady = function() {
 		clearTimeout( this._timeout );
 	}
 
-	this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, this._name + ' ready' );
+	var dependencyType = this._dependency.type ? ': ' + this._dependency.type : ''
+	this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.INFO, `${this._name} ready${dependencyType}`  );
 	process.nextTick( this._emitReady.bind( this ) );
 };
 


### PR DESCRIPTION
@WolframHempel @timaschew 

I was going through the documentation and testing some things, and the valve permissions never actually printed where they were being loaded from.

I know this is way too close to the 1.0 release, but I tested this and it works across all authentication handlers ( minor change ) since all of our connectors isReady events are sync ( file loads so fast it worked regardless ), and also works if they are async.

I think this should go in, but I want to get some thumbs up first incase it:
1) Isn't urgent enough to bypass code freeze
2) Has any implications I can't think of