### PR TITLE
FIXES #266 and rewrites HTTP Auth request to use needle 

### DIFF
--- a/src/authentication/http-authentication-handler.js
+++ b/src/authentication/http-authentication-handler.js
@@ -20,16 +20,18 @@ module.exports = class HttpAuthenticationHandler extends EventEmitter{
 	 * @param   {Array}  settings.permittedStatusCodes an array of http status codes that qualify as permitted
 	 * @param   {Number} settings.requestTimeout time in milliseconds before the request times out if no reply is received
 	 *
+	 * @param 	{Logger} logger
+	 *
 	 * @constructor
 	 * @returns {void}
 	 */
-	constructor( settings ) {
+	constructor( settings, logger ) {
 		super();
 		this.isReady = true;
 		this.type = 'http webhook to ' + settings.endpointUrl;
 		this._settings = settings;
+		this._logger = logger;
 		this._validateSettings();
-		this._params = this._createUrlParams();
 	}
 
 	/**
@@ -45,26 +47,11 @@ module.exports = class HttpAuthenticationHandler extends EventEmitter{
 	 */
 	isValidUser( connectionData, authData, callback ) {
 		new HttpAuthenticationRequest(
-			this._params,
-			connectionData,
-			authData,
+			{ connectionData: connectionData, authData: authData },
 			this._settings,
+			this._logger,
 			callback
 		);
-	}
-
-	/**
-	 * Parses the provided endpoint URL and extends the resulting
-	 * parameter set with values for the outgoing request
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_createUrlParams() {
-		var params = url.parse( this._settings.endpointUrl );
-		params.method = 'POST';
-		params.headers = { 'Content-Type': 'application/json' };
-		return params;
 	}
 
 	/**

--- a/src/authentication/http-authentication-request.js
+++ b/src/authentication/http-authentication-request.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const http = require( 'http' );
-const utils = require( '../utils/utils' );
+const needle = require( 'needle' );
 const C = require( '../constants/constants' );
 
 /**
@@ -13,181 +12,72 @@ module.exports = class HttpAuthenticationRequest{
 	/**
 	 * Creates and issues the request and starts the timeout
 	 *
-	 * @param   {Object}   params         request parameter as created by HttpAuthenticationHandler.getParams
-	 * @param   {Object}   connectionData the handshake / tcp connection data for the incoming connection
-	 * @param   {Object}   authData       the authenticationd data the user provided
+	 * @param   {Object}   data 		  Map with authData and connectionData
 	 * @param   {Object}   settings       contains requestTimeout and permittedStatusCodes
 	 * @param   {Function} callback       Called with error, isAuthenticated, authData
+	 * @param 	{Logger}   logger
 	 *
 	 * @constructor
 	 * @returns {void}
 	 */
-	constructor( params, connectionData, authData, settings, callback ) {
-		this._postDataString = this._createPostData( connectionData, authData );
-		this._params = this._createParams( params );
-		this._timeout = setTimeout( this._onError.bind( this, 'request timed out' ), settings.requestTimeout );
+	constructor( data, settings, logger, callback ) {
 		this._settings = settings;
 		this._callback = callback;
-		this._response = null;
-		this._responseText = '';
-		this._request = http.request( this._params, this._onResponse.bind( this ) );
-		this._request.on( 'error', this._onError.bind( this ) );
-		this._request.write( this._postDataString );
-		this._request.end();
-	}
+		this._logger = logger;
 
-	/**
-	 * Copies the provided parameters and adds a content length
-	 * header specific to this request's data
-	 *
-	 * @param   {Object}   params  request parameter as created by HttpAuthenticationHandler.getParams
-	 *
-	 * @private
-	 * @returns {Object} params
-	 */
-	_createParams( params ) {
-		params = utils.deepCopy( params );
-		params.headers[ 'Content-Length' ] = this._postDataString.length;
-		return params;
-	}
+		var options = {
+			read_timeout: settings.requestTimeout,
+			open_timeout: settings.requestTimeout,
+			timeout: settings.requestTimeout,
+			follow_max : 2,
+			json: true
+		};
 
-	/**
-	 * Creates the post data string that will be send with the request
-	 *
-	 * @param   {Object}   connectionData the handshake / tcp connection data for the incoming connection
-	 * @param   {Object}   authData       the authenticationd data the user provided
-	 *
-	 * @private
-	 * @returns {String} postData
-	 */
-	_createPostData( connectionData, authData ) {
-		return JSON.stringify({
-			connectionData: connectionData,
-			authData: authData
-		});
-	}
-
-	/**
-	 * Invoked as soon as the start of the server's response
-	 * is received. The response will be complete in onComplete
-	 *
-	 * @param   {http.IncomingMessage} response
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_onResponse( response ) {
-		this._response = response;
-		this._response.setEncoding( 'utf8' );
-		this._response.on( 'data', this._addChunk.bind( this ) );
-		this._response.on( 'end', this._onComplete.bind( this ) );
-	}
-
-	/**
-	 * Concatenate incoming, chunk encoded post data
-	 *
-	 * @param {String} chunk Chunks are already converted to utf-8 strings
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_addChunk( chunk ) {
-		this._responseText += chunk;
+		needle.post( settings.endpointUrl, data, options, this._onComplete.bind( this ) );
 	}
 
 	/**
 	 * Invoked for completed responses, whether succesful
 	 * or erroures
 	 *
+	 * @param {Error} error HTTP Error
+	 * @param {http.Response} response
+	 *
 	 * @private
 	 * @returns {void}
 	 */
-	_onComplete() {
-		if( this._settings.permittedStatusCodes.indexOf( this._response.statusCode ) === -1 ) {
-			this._onServerReject( this._response.statusCode );
+	_onComplete( error, response ) {
+		if( error ) {
+			this._settings.logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth error: ' + error );
+			this._callback( false, null );
+			this._destroy();
+			return;
+		}
+
+		if( response.statusCode >= 500 && response.statusCode < 600 ) {
+			this._settings.logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth server error: ' + response.body );
+		}
+
+		if( this._settings.permittedStatusCodes.indexOf( response.statusCode ) === -1 ) {
+			this._callback( false, response.body || null )
+		} else if( response.body && typeof response.body === 'string' ) {
+			this._callback( true, { username: response.body });
 		} else {
-			this._callback( true, this._getResponseData() );
+			this._callback( true, response.body || null );
 		}
 
 		this._destroy();
 	}
 
 	/**
-	 * If the server provided data in the message body, this method
-	 * tries to parse it to a json object or return it as a string
-	 * if unparsable
-	 *
-	 * @private
-	 * @returns {String|Object} data
-	 */
-	_getResponseData() {
-		if( !this._responseText ) {
-			return null;
-		} else {
-			try{
-				return JSON.parse( this._responseText );
-			} catch( e ) {
-				return { username: this._responseText }
-			}
-		}
-	}
-
-	/**
-	 * Handles rejection messages from the server
-	 *
-	 * @param   {Number} statusCode the http status code the server provided
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_onServerReject( statusCode ) {
-		if( statusCode >= 500 && statusCode < 600 ) {
-			this._logError( 'received error for http auth request: ' + this._responseText );
-		}
-		this._callback( false, this._getResponseData() );
-	}
-
-	/**
-	 * Handles errors that occured while making the request
-	 *
-	 * @param   {Error|String} error
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_onError( error ) {
-		this._logError( 'error while making authentication request: ' + error.toString() );
-		this._callback( false );
-		this._destroy();
-	}
-
-	/**
-	 * Logs http related errors as warnings
-	 *
-	 * @param   {String} errorMsg
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_logError( errorMsg ) {
-		this._settings.logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, errorMsg );
-	}
-
-	/**
-	 * Destroys the request, either as result of an error or its completion
+	 * Destroys the class
 	 *
 	 * @private
 	 * @returns {void}
 	 */
 	_destroy() {
-		clearTimeout( this._timeout );
-		this._request.removeAllListeners();
-		if( this._response ) this._response.removeAllListeners();
-		this._postDataString = null;
 		this._callback = null;
-		this._params = null;
-		this._request = null;
-		this._response = null;
-		this._responseText = null;
+		this._settings = null;
+		this._logger = null;
 	}
 }

--- a/src/config/config-initialiser.js
+++ b/src/config/config-initialiser.js
@@ -227,7 +227,7 @@ function handleAuthStrategy( config ) {
 		config.auth.options.path = fileUtils.lookupConfRequirePath( config.auth.options.path );
 	}
 
-	config.authenticationHandler = new ( authStrategies[ config.auth.type ] )( config.auth.options );
+	config.authenticationHandler = new ( authStrategies[ config.auth.type ] )( config.auth.options, config.logger );
 }
 
 /**

--- a/test/authentication/http-authentication-handlerSpec.js
+++ b/test/authentication/http-authentication-handlerSpec.js
@@ -37,7 +37,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 				authData: { 'username': 'userA' }
 			});
 			expect( server.lastRequestMethod ).toBe( 'POST' );
-			expect( server.lastRequestHeaders[ 'content-type' ] ).toBe( 'application/json' );
+			expect( server.lastRequestHeaders[ 'content-type' ] ).toContain( 'application/json' );
 			server.respondWith( 200, { authData: { 'extra': 'data' } } );
 		});
 
@@ -58,7 +58,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 				authData: { 'username': 'userA' }
 			});
 			expect( server.lastRequestMethod ).toBe( 'POST' );
-			expect( server.lastRequestHeaders[ 'content-type' ] ).toBe( 'application/json' );
+			expect( server.lastRequestHeaders[ 'content-type' ] ).toContain( 'application/json' );
 			server.respondWith( 401 );
 		});
 
@@ -80,7 +80,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 				authData: { 'username': 'userA' }
 			});
 			expect( server.lastRequestMethod ).toBe( 'POST' );
-			expect( server.lastRequestHeaders[ 'content-type' ] ).toBe( 'application/json' );
+			expect( server.lastRequestHeaders[ 'content-type' ] ).toContain( 'application/json' );
 			server.respondWith( 200, '' );
 		});
 
@@ -101,7 +101,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 				authData: { 'username': 'userA' }
 			});
 			expect( server.lastRequestMethod ).toBe( 'POST' );
-			expect( server.lastRequestHeaders[ 'content-type' ] ).toBe( 'application/json' );
+			expect( server.lastRequestHeaders[ 'content-type' ] ).toContain( 'application/json' );
 			server.respondWith( 200, 'userA' );
 		});
 
@@ -122,7 +122,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 
 		authenticationHandler.isValidUser( connectionData, authData, function( result, data ){
 			expect( result ).toBe( false );
-			expect( logger.log ).toHaveBeenCalledWith( 2, 'AUTH_ERROR', 'received error for http auth request: oh dear' );
+			expect( logger.log ).toHaveBeenCalledWith( 2, 'AUTH_ERROR',  'http auth server error: oh dear' );
 			done();
 		});
 	});
@@ -139,8 +139,7 @@ describe( 'it forwards authentication attempts as http post requests to a specif
 
 		authenticationHandler.isValidUser( connectionData, authData, function( result, data ){
 			expect( result ).toBe( false );
-			expect( arguments.length ).toBe( 1 );
-			expect( logger.log ).toHaveBeenCalledWith( 2, 'AUTH_ERROR', 'error while making authentication request: request timed out' );
+			expect( logger.log ).toHaveBeenCalledWith( 2, 'AUTH_ERROR', 'http auth error: Error: socket hang up' );
 			server.respondWith( 200 );
 			done();
 		});

--- a/test/test-helper/test-http-server.js
+++ b/test/test-helper/test-http-server.js
@@ -31,6 +31,7 @@ module.exports = class TestHttpServer extends EventEmitter{
 		if( typeof data === 'object' ) {
 			data = JSON.stringify( data );
 		}
+		this._response.setHeader( 'content-type', 'application/json');
 		this._response.writeHead( statusCode );
 		this._response.end( data );
 	}


### PR DESCRIPTION
This fixes two problems regarding the HTTP Auth type

Logger is now passed on, fixing #266 

Http Auth Request is now using needle, solving server crashing if remote http server was shut down during request. (Plus we get some nice redirect and HTTPS support)