### PR TITLE
Fix #320 TypeError: Cannot read property 'log' of undefined

### DIFF
--- a/src/authentication/http-authentication-request.js
+++ b/src/authentication/http-authentication-request.js
@@ -48,14 +48,14 @@ module.exports = class HttpAuthenticationRequest{
 	 */
 	_onComplete( error, response ) {
 		if( error ) {
-			this._settings.logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth error: ' + error );
+			this._logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth error: ' + error );
 			this._callback( false, null );
 			this._destroy();
 			return;
 		}
 
 		if( response.statusCode >= 500 && response.statusCode < 600 ) {
-			this._settings.logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth server error: ' + response.body );
+			this._logger.log( C.LOG_LEVEL.WARN, C.EVENT.AUTH_ERROR, 'http auth server error: ' + response.body );
 		}
 
 		if( this._settings.permittedStatusCodes.indexOf( response.statusCode ) === -1 ) {


### PR DESCRIPTION
Changed this._settings.logger.log to this._logger.log in _onComplete because the former is a null reference and creates errors when attempting to log.