### PR TITLE
Try to load config file if no params was passed to server constructor

### DIFF
--- a/src/deepstream.io.js
+++ b/src/deepstream.io.js
@@ -33,7 +33,7 @@ const STATES = C.STATES;
  * @copyright 2016 deepstreamHub GmbH
  * @author deepstreamHub GmbH
  *
- * @param {Object} config Configuration object
+ * @param {Object} [config] Configuration object
  *
  * @constructor
  */

--- a/src/deepstream.io.js
+++ b/src/deepstream.io.js
@@ -233,15 +233,25 @@ Deepstream.prototype.convertTyped = function( value ) {
  * @returns {void}
  */
 Deepstream.prototype._loadConfig = function( config ) {
-	if ( config === null || typeof config === 'string' ) {
-		var result = jsYamlLoader.loadConfig( config );
-		this._configFile = result.file;
-		config = result.config;
-	} else {
-		var rawConfig = utils.merge( defaultOptions.get(), config );
-		config = configInitialiser.initialise( rawConfig );
+	if( !config || typeof config === 'string' ) {
+		try {
+			var result = jsYamlLoader.loadConfig( config );
+			this._configFile = result.file;
+			this._options = result.config;
+
+			return;
+		} catch ( e ) {
+			process.stdout.write( "No config file found; use default config" + EOL );
+			config = {};
+		}
 	}
-	this._options = config;
+
+	if( typeof config !== 'object' ) {
+		throw new Error( "Config must be object or path to config file" )
+	}
+
+	var rawConfig = utils.merge( defaultOptions.get(), config );
+	this._options = configInitialiser.initialise( rawConfig );
 };
 
 /**


### PR DESCRIPTION
Previous strategy was to load default config. Check config type also.

```javascript
// previous
const server = new Deepstream(); // load defaults
const server = new Deepstream(null); // try to load config file; throw exception if not found
const server = new Deepstream({}); // load defaults
const server = new Deepstream({port: 1234}); // extend defaults

// new
const server = new Deepstream(); // try to load config file; fallback to defaults
const server = new Deepstream(null); // try to load config file; fallback to defaults
const server = new Deepstream({}); // load defaults
const server = new Deepstream({port: 1234}); // extend defaults
```
