### PR TITLE
Moved callback into own function, added docs

### DIFF
--- a/src/permission/rule-application.js
+++ b/src/permission/rule-application.js
@@ -9,7 +9,6 @@ var C = require( '../constants/constants' );
 var RecordRequest = require( '../record/record-request' );
 var messageParser = require( '../message/message-parser' );
 var JsonPath = require( '../record/json-path' );
-var utils = require( '../utils/utils' );
 
 /**
  * This class handles the evaluation of a single rule. It creates
@@ -382,16 +381,29 @@ RuleApplication.prototype._loadRecord = function( recordName ) {
 
 	this._recordData[ recordName ] = LOADING;
 
-	this._params.recordHandler.runWhenRecordStable( recordName, () => {
-		new RecordRequest(
-			recordName,
-			this._params.options,
-			null,
-			this._onLoadComplete.bind( this, recordName ),
-			this._onLoadError.bind( this, recordName )
-		);
-	});
+	this._params.recordHandler.runWhenRecordStable( recordName,
+    this._createNewRecordRequest.bind( this ) );
 };
+
+/**
+ * Load the record data from the cache for permissioning. This method should be
+ * called once the record is stable – meaning there are no remaining writes
+ * waiting to be written to the cache.
+ *
+ * @param   {String} recordName
+ *
+ * @private
+ * @returns {void}
+ */
+RuleApplication.prototype._createNewRecordRequest = function( recordName ) {
+	new RecordRequest(
+		recordName,
+		this._params.options,
+		null,
+		this._onLoadComplete.bind( this, recordName ),
+		this._onLoadError.bind( this, recordName )
+	);
+}
 
 /**
  * This method is passed to the rule function as _ to allow crossReferencing

--- a/src/permission/rule-application.js
+++ b/src/permission/rule-application.js
@@ -381,8 +381,10 @@ RuleApplication.prototype._loadRecord = function( recordName ) {
 
 	this._recordData[ recordName ] = LOADING;
 
-	this._params.recordHandler.runWhenRecordStable( recordName,
-    this._createNewRecordRequest.bind( this ) );
+	this._params.recordHandler.runWhenRecordStable(
+		recordName,
+		this._createNewRecordRequest.bind( this )
+	);
 };
 
 /**

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -440,7 +440,7 @@ RecordHandler.prototype.removeRecordRequest = function( recordName ) {
 	}
 
 	callback = this._recordRequestsInProgress[ recordName ].splice( 0, 1 )[ 0 ];
-	callback();
+	callback( recordName );
 };
 
 /**
@@ -458,7 +458,7 @@ RecordHandler.prototype.removeRecordRequest = function( recordName ) {
 RecordHandler.prototype.runWhenRecordStable = function( recordName, callback ) {
 	if( !this._recordRequestsInProgress[ recordName ] ) {
 		this._recordRequestsInProgress[ recordName ] = [];
-		callback();
+		callback( recordName );
 	} else {
 		this._recordRequestsInProgress[ recordName ].push( callback );
 	}

--- a/test/permission/config-permission-handler-basicSpec.js
+++ b/test/permission/config-permission-handler-basicSpec.js
@@ -15,7 +15,7 @@ var lastError = function() {
 
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';
@@ -260,7 +260,7 @@ describe( 'loads permissions repeatedly', function(){
 
 	it( 'creates the permissionHandler', function(){
 		permissionHandler = new ConfigPermissionHandler( options, getBasePermissions() );
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		expect( permissionHandler.isReady ).toBe( true );
 	});
 

--- a/test/permission/config-permission-handler-createSpec.js
+++ b/test/permission/config-permission-handler-createSpec.js
@@ -15,7 +15,7 @@ var options = {
 };
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';

--- a/test/permission/config-permission-handler-cross-referenceSpec.js
+++ b/test/permission/config-permission-handler-cross-referenceSpec.js
@@ -21,7 +21,7 @@ var options = {
 
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';

--- a/test/permission/config-permission-handler-loadSpec.js
+++ b/test/permission/config-permission-handler-loadSpec.js
@@ -11,7 +11,7 @@ describe( 'permission handler is initialised correctly', function(){
 				}
 			}
 		});
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		expect( permissionHandler.isReady ).toBe( false );
 		permissionHandler.init();
 		permissionHandler.on( 'error', function( error ){
@@ -33,7 +33,7 @@ describe( 'permission handler is initialised correctly', function(){
 				}
 			}
 		});
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		expect( permissionHandler.isReady ).toBe( false );
 		permissionHandler.init();
 		permissionHandler.on( 'error', function( error ){
@@ -55,7 +55,7 @@ describe( 'permission handler is initialised correctly', function(){
 				}
 			}
 		});
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		expect( permissionHandler.isReady ).toBe( false );
 		permissionHandler.init();
 		permissionHandler.on( 'error', function( error ){
@@ -77,7 +77,7 @@ describe( 'permission handler is initialised correctly', function(){
 				}
 			}
 		});
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		expect( permissionHandler.isReady ).toBe( false );
 		permissionHandler.init();
 		permissionHandler.on( 'error', function( error ){
@@ -104,7 +104,7 @@ describe( 'it loads a new config during runtime', function(){
 				}
 			}
 		});
-		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+		permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 		permissionHandler.init();
 		permissionHandler.on( 'error', onError );
 		expect( permissionHandler.isReady ).toBe( false );

--- a/test/permission/config-permission-handler-nested-cross-referenceSpec.js
+++ b/test/permission/config-permission-handler-nested-cross-referenceSpec.js
@@ -21,7 +21,7 @@ var options = {
 
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';

--- a/test/permission/config-permission-handler-otherSpec.js
+++ b/test/permission/config-permission-handler-otherSpec.js
@@ -12,7 +12,7 @@ var options = {
 };
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';

--- a/test/permission/config-permission-handler-record-patchSpec.js
+++ b/test/permission/config-permission-handler-record-patchSpec.js
@@ -21,7 +21,7 @@ var lastError = function() {
 
 var testPermission = function( permissions, message, username, userdata, callback ) {
 	var permissionHandler = new ConfigPermissionHandler( options, permissions );
-	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c(); }});
+	permissionHandler.setRecordHandler({ removeRecordRequest: () => {}, runWhenRecordStable: ( r, c ) => { c( r ); }});
 	var permissionResult;
 
 	username = username || 'someUser';


### PR DESCRIPTION
Moved the _createNewRecordRequest callback for RuleApplication.runWhenRecordStable into its own method, added documentation and tests for the modified function signature.