### PR TITLE
adding setup handshake data and tests

### DIFF
--- a/src/message/socket-wrapper.js
+++ b/src/message/socket-wrapper.js
@@ -26,6 +26,8 @@ var SocketWrapper = function( socket, options ) {
 	this.authAttempts = 0;
 	this.setMaxListeners( 0 );
 	this.uuid = Math.random();
+	this._handshakeData = null;
+	this._setUpHandshakeData();
 
 	this._queuedMessages = [];
 	this._currentPacketMessageCount = 0;
@@ -107,16 +109,7 @@ SocketWrapper.finalizeMessage = function( preparedMessage ) {
  * @returns {Object} handshakeData
  */
 SocketWrapper.prototype.getHandshakeData = function() {
-	var handshakeData = {
-		remoteAddress: this.socket._socket.remoteAddress
-	};
-
-	if( this.socket.upgradeReq ) {
-		handshakeData.headers = this.socket.upgradeReq.headers;
-		handshakeData.referer = this.socket.upgradeReq.headers.referer;
-	}
-
-	return handshakeData;
+	return this._handshakeData;
 };
 
 /**
@@ -197,5 +190,23 @@ SocketWrapper.prototype._onSocketClose = function() {
 	this.emit( 'close' );
 	this._options.logger.log( C.LOG_LEVEL.INFO, C.EVENT.CLIENT_DISCONNECTED, this.user );
 };
+
+/**
+ * Initialise the handshake data from the initial connection
+ * 
+ * @private
+ * @returns void
+ */
+SocketWrapper.prototype._setUpHandshakeData = function() {
+	this._handshakeData = {
+		remoteAddress: this.socket._socket.remoteAddress
+	};
+
+	if( this.socket.upgradeReq ) {
+		this._handshakeData.headers = this.socket.upgradeReq.headers;
+		this._handshakeData.referer = this.socket.upgradeReq.headers.referer;
+	}
+	return this._handshakeData;
+}
 
 module.exports = SocketWrapper;

--- a/test/message/socket-wrapperSpec.js
+++ b/test/message/socket-wrapperSpec.js
@@ -2,15 +2,25 @@ var SocketMock = require( '../mocks/socket-mock' );
 var SocketWrapper = require( '../../src/message/socket-wrapper' );
 
 describe( 'socket-wrapper creates a unified interface for sockets', function(){
+	var socket = new SocketMock(),
+		socketWrapper;
+	socket._socket.remoteAddress = 'some-address';
+	socket.upgradeReq = {
+		headers: {
+			referer: 'some-referer'
+		}
+	};
+
 	it( 'creates a SocketWrapper', function(){
-		var socket = new SocketMock();
-		socket._socket.remoteAddress = 'some-address';
-		socket.upgradeReq = {
-			headers: {
-				referer: 'some-referer'
-			}
-		};
-		var socketWrapper = new SocketWrapper( socket, {} );
+		socketWrapper = new SocketWrapper( socket, {} );
+		expect( socketWrapper.getHandshakeData() ).toEqual({
+			headers: { referer: 'some-referer' },
+			referer: 'some-referer',
+			remoteAddress: 'some-address'
+		});
+	});
+
+	it( 'handshake data is able to be queried for again', function() {
 		expect( socketWrapper.getHandshakeData() ).toEqual({
 			headers: { referer: 'some-referer' },
 			referer: 'some-referer',


### PR DESCRIPTION
Fixes #450.

Previously handshake data was overwritten with every call to getHandshakeData().