### PR TITLE
fixing multiple logins from single user

### DIFF
--- a/src/presence/presence-handler.js
+++ b/src/presence/presence-handler.js
@@ -139,5 +139,4 @@ module.exports = class PresenceHandler {
     const removeMsg = messageBuilder.getMsg(C.TOPIC.PRESENCE, C.ACTIONS.PRESENCE_LEAVE, [username])
     this._presenceRegistry.sendToSubscribers(C.TOPIC.PRESENCE, removeMsg)
   }
-
 }

--- a/src/presence/presence-handler.js
+++ b/src/presence/presence-handler.js
@@ -20,7 +20,7 @@ module.exports = class PresenceHandler {
 
   constructor(options) {
     this._options = options
-
+    this._localClients = {}
     this._connectionEndpoint = options.connectionEndpoint
     this._connectionEndpoint.on('client-connected', this._handleJoin.bind(this))
     this._connectionEndpoint.on('client-disconnected', this._handleLeave.bind(this))
@@ -68,7 +68,13 @@ module.exports = class PresenceHandler {
   * @returns {void}
   */
   _handleJoin(socketWrapper) {
-    this._connectedClients.add(socketWrapper.user)
+    if(this._connectedClients.has(socketWrapper.user)) {
+      this._localClients[socketWrapper.user]++
+    } else {
+      this._connectedClients.add(socketWrapper.user)
+      this._localClients[socketWrapper.user] = 1
+    }
+    
   }
 
   /**
@@ -80,7 +86,12 @@ module.exports = class PresenceHandler {
   * @returns {void}
   */
   _handleLeave(socketWrapper) {
-    this._connectedClients.remove(socketWrapper.user)
+    if(this._localClients[socketWrapper.user] === 1) {
+      this._localClients[socketWrapper.user]--
+      this._connectedClients.remove(socketWrapper.user)
+    } else {
+      this._localClients[socketWrapper.user]--
+    }
   }
 
   /**

--- a/test/presence/presence-handlerSpec.js
+++ b/test/presence/presence-handlerSpec.js
@@ -72,6 +72,13 @@ describe('presence handler', () => {
     expect(userThree.socket.lastSendMessage).toBeNull()
   })
 
+  it('a duplicate client logs out and subscribed clients are not notified', () => {
+    options.connectionEndpoint.emit('client-disconnected', userTwoAgain)
+    expect(userOne.socket.lastSendMessage).toBeNull()
+    expect(userTwo.socket.lastSendMessage).toBeNull()
+    expect(userThree.socket.lastSendMessage).toBeNull()
+  })
+
   it('returns multiple uses when queried', () => {
     presenceHandler.handle(userOne, queryMessage)
     expect(userOne.socket.lastSendMessage).toBe(_msg('U|Q|Marge|Bart+'))


### PR DESCRIPTION
New functionality should only notify when a user first logs in, and when the last instance of that user logs out.