### PR TITLE
Replace os.tmpDir() with os.tmpdir()

### DIFF
--- a/bin/pid-helper.js
+++ b/bin/pid-helper.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 
-const DEFAULT_PID_FILE = path.join(os.tmpDir(), 'deepstream.pid')
+const DEFAULT_PID_FILE = path.join(os.tmpdir(), 'deepstream.pid')
 const PID_FILE = process.env.DEEPSTREAM_PID_FILE || DEFAULT_PID_FILE
 
 /**


### PR DESCRIPTION
These functions are aliases:
https://github.com/nodejs/node/blob/4a5c719be50c7998684768b54d06860cb2c1d6fb/lib/os.js#L54-L55

This silences a warning when starting `bin/deepstream`:
`(node:1224) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.`