### PR TITLE
message-processor: Optimized + Ensure message ordering

### DIFF
--- a/src/message/connection-endpoint.js
+++ b/src/message/connection-endpoint.js
@@ -203,25 +203,25 @@ module.exports = class ConnectionEndpoint extends events.EventEmitter {
    * @returns {void}
    */
   _processConnectionMessage(socketWrapper, connectionMessage) {
-    const msg = messageParser.parse(connectionMessage)[0]
-
-    if (msg === null || msg === undefined) {
-      this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.MESSAGE_PARSE_ERROR, connectionMessage)
-      socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.MESSAGE_PARSE_ERROR, connectionMessage)
-      socketWrapper.destroy()
-    } else if (msg.topic !== C.TOPIC.CONNECTION) {
-      this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.INVALID_MESSAGE, `invalid connection message ${connectionMessage}`)
-      socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.INVALID_MESSAGE, 'invalid connection message')
-    } else if (msg.action === C.ACTIONS.PONG) {
-      return
-    } else if (msg.action === C.ACTIONS.CHALLENGE_RESPONSE) {
-      socketWrapper.socket.removeListener('message', socketWrapper.connectionCallback)
-      socketWrapper.socket.on('message', socketWrapper.authCallBack)
-      socketWrapper.sendMessage(C.TOPIC.CONNECTION, C.ACTIONS.ACK)
-    } else {
-      this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.UNKNOWN_ACTION, msg.action)
-      socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.UNKNOWN_ACTION, `unknown action ${msg.action}`)
-    }
+    messageParser.parse(connectionMessage, msg => {
+      if (msg === null || msg === undefined) {
+        this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.MESSAGE_PARSE_ERROR, connectionMessage)
+        socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.MESSAGE_PARSE_ERROR, connectionMessage)
+        socketWrapper.destroy()
+      } else if (msg.topic !== C.TOPIC.CONNECTION) {
+        this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.INVALID_MESSAGE, `invalid connection message ${connectionMessage}`)
+        socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.INVALID_MESSAGE, 'invalid connection message')
+      } else if (msg.action === C.ACTIONS.PONG) {
+        return
+      } else if (msg.action === C.ACTIONS.CHALLENGE_RESPONSE) {
+        socketWrapper.socket.removeListener('message', socketWrapper.connectionCallback)
+        socketWrapper.socket.on('message', socketWrapper.authCallBack)
+        socketWrapper.sendMessage(C.TOPIC.CONNECTION, C.ACTIONS.ACK)
+      } else {
+        this._options.logger.log(C.LOG_LEVEL.WARN, C.EVENT.UNKNOWN_ACTION, msg.action)
+        socketWrapper.sendError(C.TOPIC.CONNECTION, C.EVENT.UNKNOWN_ACTION, `unknown action ${msg.action}`)
+      }
+    })
   }
 
   /**
@@ -238,60 +238,61 @@ module.exports = class ConnectionEndpoint extends events.EventEmitter {
    * @returns {void}
    */
   _authenticateConnection(socketWrapper, disconnectTimeout, authMsg) {
-    const msg = messageParser.parse(authMsg)[0]
-    let authData
-    let errorMsg
+    messageParser.parse(authMsg, msg => {
+      let authData
+      let errorMsg
 
-    /**
-     * Ignore pong messages
-     */
-    if (msg && msg.topic === C.TOPIC.CONNECTION && msg.action === C.ACTIONS.PONG) {
-      return
-    }
-
-    /**
-     * Log the authentication attempt
-     */
-    const logMsg = `${socketWrapper.getHandshakeData().remoteAddress}: ${authMsg}`
-    this._options.logger.log(C.LOG_LEVEL.DEBUG, C.EVENT.AUTH_ATTEMPT, logMsg)
-
-    /**
-     * Ensure the message is a valid authentication message
-     */
-    if (!msg ||
-        msg.topic !== C.TOPIC.AUTH ||
-        msg.action !== C.ACTIONS.REQUEST ||
-        msg.data.length !== 1
-      ) {
-      errorMsg = this._options.logInvalidAuthData === true ? authMsg : ''
-      this._sendInvalidAuthMsg(socketWrapper, errorMsg)
-      return
-    }
-
-    /**
-     * Ensure the authentication data is valid JSON
-     */
-    try {
-      authData = this._getValidAuthData(msg.data[0])
-    } catch (e) {
-      errorMsg = 'Error parsing auth message'
-
-      if (this._options.logInvalidAuthData === true) {
-        errorMsg += ` "${authMsg}": ${e.toString()}`
+      /**
+       * Ignore pong messages
+       */
+      if (msg && msg.topic === C.TOPIC.CONNECTION && msg.action === C.ACTIONS.PONG) {
+        return
       }
 
-      this._sendInvalidAuthMsg(socketWrapper, errorMsg)
-      return
-    }
+      /**
+       * Log the authentication attempt
+       */
+      const logMsg = `${socketWrapper.getHandshakeData().remoteAddress}: ${authMsg}`
+      this._options.logger.log(C.LOG_LEVEL.DEBUG, C.EVENT.AUTH_ATTEMPT, logMsg)
 
-    /**
-     * Forward for authentication
-     */
-    this._options.authenticationHandler.isValidUser(
-      socketWrapper.getHandshakeData(),
-      authData,
-      this._processAuthResult.bind(this, authData, socketWrapper, disconnectTimeout)
-    )
+      /**
+       * Ensure the message is a valid authentication message
+       */
+      if (!msg ||
+          msg.topic !== C.TOPIC.AUTH ||
+          msg.action !== C.ACTIONS.REQUEST ||
+          msg.data.length !== 1
+        ) {
+        errorMsg = this._options.logInvalidAuthData === true ? authMsg : ''
+        this._sendInvalidAuthMsg(socketWrapper, errorMsg)
+        return
+      }
+
+      /**
+       * Ensure the authentication data is valid JSON
+       */
+      try {
+        authData = this._getValidAuthData(msg.data[0])
+      } catch (e) {
+        errorMsg = 'Error parsing auth message'
+
+        if (this._options.logInvalidAuthData === true) {
+          errorMsg += ` "${authMsg}": ${e.toString()}`
+        }
+
+        this._sendInvalidAuthMsg(socketWrapper, errorMsg)
+        return
+      }
+
+      /**
+       * Forward for authentication
+       */
+      this._options.authenticationHandler.isValidUser(
+        socketWrapper.getHandshakeData(),
+        authData,
+        this._processAuthResult.bind(this, authData, socketWrapper, disconnectTimeout)
+      )
+    })
   }
 
   /**

--- a/src/message/message-parser.js
+++ b/src/message/message-parser.js
@@ -48,17 +48,14 @@ module.exports = class MessageParser {
    *                    data: <array of strings>
    *                  }
    */
-  static parse(message) {
-    const parsedMessages = []
+  static parse(message, callback) {
     const rawMessages = message.split(C.MESSAGE_SEPERATOR)
 
     for (let i = 0; i < rawMessages.length; i++) {
       if (rawMessages[i].length > 2) {
-        parsedMessages.push(this.parseMessage(rawMessages[i]))
+        callback(this.parseMessage(rawMessages[i]), message)
       }
     }
-
-    return parsedMessages
   }
 
   /**

--- a/src/message/message-queue.js
+++ b/src/message/message-queue.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const messageParser = require('./message-parser')
+const C = require('../constants/constants')
+
+const STATE = {
+  IDLE: 0,
+  ASYNC: 1,
+  SYNC: 2,
+  WAITING: 3,
+}
+
+module.exports = class MessageQueue {
+
+  constructor(options, socket) {
+    this._processor = options.processor
+    this._permissionHandler = options.permissionHandler
+    this._logger = options.logger
+    this._socket = socket
+    this._messages = []
+    this._index = 0
+    this._state = STATE.IDLE
+
+    this._onMessage = this._onMessage.bind(this)
+    this._onResponse = this._onResponse.bind(this)
+  }
+
+  /**
+   * There will only ever be one consumer of forwarded messages. So rather than using
+   * events - and their performance overhead - the messageProcessor exposes
+   * this method that's expected to be overwritten.
+   *
+   * @param   {SocketWrapper} socketWrapper
+   * @param   {Object} message the parsed message
+   *
+   * @overwrite
+   *
+   * @returns {void}
+   */
+  onAuthenticatedMessage(socketWrapper, message) {
+  }
+
+  /**
+   * This method is the way the message queue accepts input. It receives arrays
+   * of parsed messages, iterates through them and issues permission requests for
+   * each individual message
+   *
+   * @todo The responses from the permissionHandler might arive in any arbitrary order - order them
+   * @todo Handle permission handler timeouts
+   *
+   * @param   {SocketWrapper} socketWrapper
+   * @param   {Object} message parsed message
+   *
+   * @returns {void}
+   */
+  process(rawMessage) {
+    messageParser.parse(rawMessage, this._onMessage)
+  }
+
+  _onMessage(message, rawMessage) {
+    if (!message) {
+      this._logger.log(C.LOG_LEVEL.WARN, C.EVENT.MESSAGE_PARSE_ERROR, rawMessage)
+      this._socket.sendError(C.TOPIC.ERROR, C.EVENT.MESSAGE_PARSE_ERROR, rawMessage)
+      return
+    }
+
+    if (message.topic === C.TOPIC.CONNECTION && message.action === C.ACTIONS.PONG) {
+      return
+    }
+
+    this._messages.push(message)
+
+    if (this._state !== STATE.IDLE) {
+      return
+    }
+
+    this._next()
+  }
+
+  _onResponse(error, result) {
+    const message = this._messages[this._index]
+
+    this._messages[this._index++] = undefined
+
+    if (error) {
+      this._logger.log(C.LOG_LEVEL.WARN, C.EVENT.MESSAGE_PERMISSION_ERROR, error.toString())
+      this._sendError(C.EVENT.MESSAGE_PERMISSION_ERROR, message)
+    } else if (!result) {
+      this._sendError(C.EVENT.MESSAGE_DENIED, message)
+    }
+
+    if (!error && result) {
+      this.onAuthenticatedMessage(this._socket, message)
+    }
+
+    if (this._state === STATE.WAITING) {
+      this._state = STATE.SYNC
+    } else if (this._state === STATE.ASYNC) {
+      this._next()
+    } else {
+      throw new Error(`invalid message queue state ${this._state}`)
+    }
+  }
+
+  _next() {
+    while (true) {
+      const message = this._messages[this._index]
+
+      if (!message) {
+        this._index = 0
+        this._state = STATE.IDLE
+        this._messages.splice(0, this._messages.length)
+        break
+      }
+
+      // Determine (STATE.WAITING) if canPerformAction is executed synchronously (STATE.SYNC) or
+      // (STATE.ASYNC) asynchronously.
+      // If executed synchronously we can iteratively continue processing messages otherwise
+      // break and continue once callback is invoked asynchronously.
+      // This avoids deep recursion and stackoverflow when canPerformAction invokes the callback
+      // synchronously.
+      this._state = STATE.WAITING
+
+      this._permissionHandler.canPerformAction(
+        this._socket.user,
+        message,
+        this._onResponse,
+        this._socket.authData
+      )
+
+      if (this._state === STATE.WAITING) {
+        this._state = STATE.ASYNC
+        break
+      }
+    }
+  }
+
+  _sendError(event, message) {
+    let data = [ message.data[0], message.action ]
+    if (message.data.length > 1) {
+      data = data.concat(message.data.slice(1))
+    }
+    this._socket.sendError(message.topic, event, data)
+  }
+}

--- a/src/message/socket-wrapper.js
+++ b/src/message/socket-wrapper.js
@@ -189,7 +189,7 @@ SocketWrapper.prototype.destroy = function () {
  */
 SocketWrapper.prototype._onSocketClose = function () {
   this.isClosed = true
-  this.emit('close')
+  this.emit('close', this)
   this._options.logger.log(C.LOG_LEVEL.INFO, C.EVENT.CLIENT_DISCONNECTED, this.user)
   this.socket.removeAllListeners()
 }

--- a/test/message/message-parserSpec.js
+++ b/test/message/message-parserSpec.js
@@ -7,43 +7,49 @@ describe('message parser processes raw messages correctly', () => {
   let x = String.fromCharCode(30), // ASCII Record Seperator 1E
     y = String.fromCharCode(31) // ASCII Unit Separator 1F
 
+  function parse(str) {
+    const messages = []
+    messageParser.parse(str, message => messages.push(message))
+    return messages.length ? messages : null
+  }
+
   it('parses record messages correctly', () => {
-    expect(messageParser.parse(`record${y}C${y}user/someId`)).toEqual([{
+    expect(parse(`record${y}C${y}user/someId`)).toEqual([{
       topic: 'record',
       raw: `record${y}C${y}user/someId`,
       action: 'C',
       data: ['user/someId']
     }])
 
-    expect(messageParser.parse(`record${y}C${y}user/someId${y}{"firstname":"Wolfram"}`)).toEqual([{
+    expect(parse(`record${y}C${y}user/someId${y}{"firstname":"Wolfram"}`)).toEqual([{
       topic: 'record',
       raw: `record${y}C${y}user/someId${y}{"firstname":"Wolfram"}`,
       action: 'C',
       data: ['user/someId', '{"firstname":"Wolfram"}']
     }])
 
-    expect(messageParser.parse(`record${y}R${y}user/someId`)).toEqual([{
+    expect(parse(`record${y}R${y}user/someId`)).toEqual([{
       topic: 'record',
       raw: `record${y}R${y}user/someId`,
       action: 'R',
       data: ['user/someId']
     }])
 
-    expect(messageParser.parse(`record${y}U${y}user/someId${y}{"firstname":"Wolfram"}`)).toEqual([{
+    expect(parse(`record${y}U${y}user/someId${y}{"firstname":"Wolfram"}`)).toEqual([{
       topic: 'record',
       raw: `record${y}U${y}user/someId${y}{"firstname":"Wolfram"}`,
       action: 'U',
       data: ['user/someId', '{"firstname":"Wolfram"}']
     }])
 
-    expect(messageParser.parse(`record${y}D${y}user/someId`)).toEqual([{
+    expect(parse(`record${y}D${y}user/someId`)).toEqual([{
       topic: 'record',
       raw: `record${y}D${y}user/someId`,
       action: 'D',
       data: ['user/someId']
     }])
 
-    expect(messageParser.parse(`record${y}US${y}user/someId`)).toEqual([{
+    expect(parse(`record${y}US${y}user/someId`)).toEqual([{
       topic: 'record',
       raw: `record${y}US${y}user/someId`,
       action: 'US',
@@ -52,14 +58,14 @@ describe('message parser processes raw messages correctly', () => {
   })
 
   it('parses subscription messages correctly', () => {
-    expect(messageParser.parse(`listen${y}S${y}user/someId`)).toEqual([{
+    expect(parse(`listen${y}S${y}user/someId`)).toEqual([{
       topic: 'listen',
       raw: `listen${y}S${y}user/someId`,
       action: 'S',
       data: ['user/someId']
     }])
 
-    expect(messageParser.parse(`listen${y}US${y}user/someId`)).toEqual([{
+    expect(parse(`listen${y}US${y}user/someId`)).toEqual([{
       topic: 'listen',
       raw: `listen${y}US${y}user/someId`,
       action: 'US',
@@ -68,21 +74,21 @@ describe('message parser processes raw messages correctly', () => {
   })
 
   it('parses rpc messages correctly', () => {
-    expect(messageParser.parse(`RPC${y}REQ${y}addValues${y}{"val1":1,"val2":2}`)).toEqual([{
+    expect(parse(`RPC${y}REQ${y}addValues${y}{"val1":1,"val2":2}`)).toEqual([{
       topic: 'RPC',
       raw: `RPC${y}REQ${y}addValues${y}{"val1":1,"val2":2}`,
       action: 'REQ',
       data: ['addValues', '{"val1":1,"val2":2}']
     }])
 
-    expect(messageParser.parse(`RPC${y}S${y}addValues`)).toEqual([{
+    expect(parse(`RPC${y}S${y}addValues`)).toEqual([{
       topic: 'RPC',
       raw: `RPC${y}S${y}addValues`,
       action: 'S',
       data: ['addValues']
     }])
 
-    expect(messageParser.parse(`RPC${y}US${y}addValues`)).toEqual([{
+    expect(parse(`RPC${y}US${y}addValues`)).toEqual([{
       topic: 'RPC',
       raw: `RPC${y}US${y}addValues`,
       action: 'US',
@@ -91,14 +97,14 @@ describe('message parser processes raw messages correctly', () => {
   })
 
   it('parses event messages correctly', () => {
-    expect(messageParser.parse(`event${y}S${y}someEvent`)).toEqual([{
+    expect(parse(`event${y}S${y}someEvent`)).toEqual([{
       topic: 'event',
       raw: `event${y}S${y}someEvent`,
       action: 'S',
       data: ['someEvent']
     }])
 
-    expect(messageParser.parse(`event${y}US${y}someEvent`)).toEqual([{
+    expect(parse(`event${y}US${y}someEvent`)).toEqual([{
       topic: 'event',
       raw: `event${y}US${y}someEvent`,
       action: 'US',
@@ -109,7 +115,7 @@ describe('message parser processes raw messages correctly', () => {
   it('parses message blocks correctly', () => {
     const blockMsg = `record${y}C${y}user/someId${y}{"firstname":"Wolfram"}${x}RPC${y}S${y}addValues${x}event${y}S${y}someEvent`
 
-    expect(messageParser.parse(blockMsg)).toEqual([{
+    expect(parse(blockMsg)).toEqual([{
       topic: 'record',
       raw: `record${y}C${y}user/someId${y}{"firstname":"Wolfram"}`,
       action: 'C',
@@ -128,8 +134,8 @@ describe('message parser processes raw messages correctly', () => {
   })
 
   it('handles broken messages gracefully', () => {
-    expect(messageParser.parse('dfds')).toEqual([null])
-    expect(messageParser.parse(`record${y}unkn`)).toEqual([null])
-    expect(messageParser.parse(`record${y}unkn${y}aaa`)).toEqual([null])
+    expect(parse('dfds')).toEqual([null])
+    expect(parse(`record${y}unkn`)).toEqual([null])
+    expect(parse(`record${y}unkn${y}aaa`)).toEqual([null])
   })
 })


### PR DESCRIPTION
This fixes several edge cases where messages going through the permission handler can be re-ordered... e.g. a `UNSUBSCRIBE` could be handled before `READ` even though the client sent `READ` first. Same problem in other cases such as `UPDATE` and  `PATCH`.

Message ordering for a specific client should be maintained.