### PR TITLE
Prevent Scalar Values in Update Messages

### DIFF
--- a/src/record/record-transition.js
+++ b/src/record/record-transition.js
@@ -5,6 +5,7 @@ const JsonPath = require('./json-path')
 const RecordRequest = require('./record-request')
 const messageParser = require('../message/message-parser')
 const messageBuilder = require('../message/message-builder')
+const utils = require('../utils/utils')
 
 /**
  * This class manages one or more simultanious updates to the data of a record.
@@ -143,6 +144,11 @@ RecordTransition.prototype.add = function (socketWrapper, version, message) {
     try {
       data = JSON.parse(message.data[2])
     } catch (e) {
+      socketWrapper.sendError(C.TOPIC.RECORD, C.EVENT.INVALID_MESSAGE_DATA, message.raw)
+      return
+    }
+
+    if(!utils.isOfType(data, 'object') || utils.isOfType(data, 'array')) {
       socketWrapper.sendError(C.TOPIC.RECORD, C.EVENT.INVALID_MESSAGE_DATA, message.raw)
       return
     }

--- a/src/record/record-transition.js
+++ b/src/record/record-transition.js
@@ -148,7 +148,7 @@ RecordTransition.prototype.add = function (socketWrapper, version, message) {
       return
     }
 
-    if(!utils.isOfType(data, 'object') || utils.isOfType(data, 'array')) {
+    if(!utils.isOfType(data, 'object') && !utils.isOfType(data, 'array')) {
       socketWrapper.sendError(C.TOPIC.RECORD, C.EVENT.INVALID_MESSAGE_DATA, message.raw)
       return
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -69,11 +69,13 @@ exports.reverseMap = function (map) {
  * @returns {Boolean}
  */
 exports.isOfType = function (input, expectedType) {
-  if (expectedType === 'array') {
+  if(input === null) {
+    return 'null' === expectedType
+  } else if (expectedType === 'array') {
     return Array.isArray(input)
   } else if (expectedType === 'url') {
     return !!url.parse(input).host
-  }
+  } 
   return typeof input === expectedType
 }
 

--- a/test/record/record-transitionSpec.js
+++ b/test/record/record-transitionSpec.js
@@ -97,6 +97,50 @@ describe('record transitions', () => {
       expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
     })
 
+     it('adds a message with null data to the queue', () => {
+      socketWrapper.socket.lastSendMessage = null
+      recordTransition.add(socketWrapper, 3, {
+        topic: 'RECORD',
+        action: 'U',
+        data: ['someRecord', 3, 'null']
+      })
+      expect(recordTransition._steps.length).toBe(2)
+      expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
+    })
+
+    it('adds a message with string data to the queue', () => {
+      socketWrapper.socket.lastSendMessage = null
+      recordTransition.add(socketWrapper, 3, {
+        topic: 'RECORD',
+        action: 'U',
+        data: ['someRecord', 3, 'This is a string']
+      })
+      expect(recordTransition._steps.length).toBe(2)
+      expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
+    })
+
+    it('adds a message with numeric data to the queue', () => {
+      socketWrapper.socket.lastSendMessage = null
+      recordTransition.add(socketWrapper, 3, {
+        topic: 'RECORD',
+        action: 'U',
+        data: ['someRecord', 3, 100.23]
+      })
+      expect(recordTransition._steps.length).toBe(2)
+      expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
+    })
+
+    it('adds a message with array data to the queue', () => {
+      socketWrapper.socket.lastSendMessage = null
+      recordTransition.add(socketWrapper, 3, {
+        topic: 'RECORD',
+        action: 'U',
+        data: ['someRecord', 3, '[100,"some string"]']
+      })
+      expect(recordTransition._steps.length).toBe(2)
+      expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
+    })
+
     it('retrieves the empty record', (done) => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()

--- a/test/record/record-transitionSpec.js
+++ b/test/record/record-transitionSpec.js
@@ -130,17 +130,6 @@ describe('record transitions', () => {
       expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
     })
 
-    it('adds a message with array data to the queue', () => {
-      socketWrapper.socket.lastSendMessage = null
-      recordTransition.add(socketWrapper, 3, {
-        topic: 'RECORD',
-        action: 'U',
-        data: ['someRecord', 3, '[100,"some string"]']
-      })
-      expect(recordTransition._steps.length).toBe(2)
-      expect(socketWrapper.socket.lastSendMessage).toBe(msg('R|E|INVALID_MESSAGE_DATA|undefined+'))
-    })
-
     it('retrieves the empty record', (done) => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()

--- a/test/utils/utilsSpec.js
+++ b/test/utils/utilsSpec.js
@@ -120,7 +120,8 @@ describe('isOfType', () => {
     expect(utils.isOfType(true, 'number')).toBe(false)
     expect(utils.isOfType(true, 'boolean')).toBe(true)
     expect(utils.isOfType({}, 'object')).toBe(true)
-    expect(utils.isOfType(null, 'object')).toBe(true)
+    expect(utils.isOfType(null, 'null')).toBe(true)
+    expect(utils.isOfType(null, 'object')).toBe(false)
     expect(utils.isOfType([], 'object')).toBe(true)
   })
 


### PR DESCRIPTION
This is a better fix for the PR i submitted for the mongo storage layer crash:
https://github.com/deepstreamIO/deepstream.io-storage-mongodb/pull/7

In essence the message specification requires update message to contain an object, but it does not enforce it. Passing a null value through the the set, causes the mongo storage layer to crash. Presumably it would have a similar affect on other storage layers.

To prevent the round trip, this detect should be done within the client itself. I will submit a separate PR for the javascript client. 