### PR TITLE
refactor: Compile listen pattern if not present

### DIFF
--- a/src/listen/listener-registry.js
+++ b/src/listen/listener-registry.js
@@ -600,8 +600,8 @@ module.exports = class ListenerRegistry {
   * @private
   * @returns {void}
   */
-  _addPattern (pattern, socketWrapper, count) {
-    if (count === 1) {
+  _addPattern (pattern /* , socketWrapper, count */) {
+    if (!this._patterns[pattern]) {
       this._patterns[pattern] = new RegExp(pattern)
     }
   }


### PR DESCRIPTION
We should compile the listener regex if it isn't present
regardless of the amount of subscriptions it currently has