### PR TITLE
fix(listener): Lazy load listener regex if needed

### DIFF
--- a/src/listen/listener-registry.js
+++ b/src/listen/listener-registry.js
@@ -775,7 +775,8 @@ module.exports = class ListenerRegistry {
       const p = patterns[pattern]
       if (p == null) {
         this._options.logger.log(C.LOG_LEVEL.WARN, '', `can't handle pattern ${pattern}`)
-        return null
+        this._addPattern(pattern)
+        p = patterns[pattern] // eslint-disable-line
       }
       if (p.test(subscriptionName)) {
         servers = servers.concat(providerRegistry.getAllServers(pattern))


### PR DESCRIPTION
An odd edge case has arised where a pattern might not
be compiled for listener comparison. This code change
tries to circumvent that change.