### PR TITLE
Delete events

### DIFF
--- a/src/event/event-handler.js
+++ b/src/event/event-handler.js
@@ -107,6 +107,7 @@ EventHandler.prototype._triggerEvent = function (socket, message) {
   this._subscriptionRegistry.sendToSubscribers(
     message.data[0],
     messageBuilder.getMsg(C.TOPIC.EVENT, C.ACTIONS.EVENT, message.data),
+    false,
     socket
   )
 }

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -290,7 +290,7 @@ RecordHandler.prototype._update = function (socketWrapper, message) {
    * storage and only broadcast the message to subscribers
    */
   if (socketWrapper === C.SOURCE_MESSAGE_CONNECTOR) {
-    this._$broadcastUpdate(recordName, message, socketWrapper)
+    this._$broadcastUpdate(recordName, message, false, socketWrapper)
     return
   }
 
@@ -317,13 +317,14 @@ RecordHandler.prototype._update = function (socketWrapper, message) {
  *
  * @param   {String} name           record name
  * @param   {Object} message        parsed and validated deepstream message
+ * @param   {Boolean} noDelay       Flag as to wether event allows delay
  * @param   {SocketWrapper} originalSender the socket the update message was received from
  *
  * @package private
  * @returns {void}
  */
-RecordHandler.prototype._$broadcastUpdate = function (name, message, originalSender) {
-  this._subscriptionRegistry.sendToSubscribers(name, message.raw, originalSender)
+RecordHandler.prototype._$broadcastUpdate = function (name, message, noDelay, originalSender) {
+  this._subscriptionRegistry.sendToSubscribers(name, message.raw, noDelay, originalSender)
 
   if (originalSender !== C.SOURCE_MESSAGE_CONNECTOR) {
     this._options.messageConnector.publish(C.TOPIC.RECORD, message)
@@ -436,7 +437,7 @@ RecordHandler.prototype._delete = function (socketWrapper, message) {
  * @returns {void}
  */
 RecordHandler.prototype._onDeleted = function (name, message, originalSender) {
-  this._$broadcastUpdate(name, message, originalSender)
+  this._$broadcastUpdate(name, message, true, originalSender)
 
   for (const subscriber of this._subscriptionRegistry.getLocalSubscribers(name)) {
     this._subscriptionRegistry.unsubscribe(name, subscriber, true)

--- a/src/record/record-transition.js
+++ b/src/record/record-transition.js
@@ -394,6 +394,7 @@ RecordTransition.prototype._onCacheResponse = function (currentStep, error) {
     this._recordHandler._$broadcastUpdate(
       this._name,
       this._currentStep.message,
+      false,
       this._currentStep.sender
     )
     this._next()

--- a/src/utils/subscription-registry.js
+++ b/src/utils/subscription-registry.js
@@ -197,12 +197,13 @@ class SubscriptionRegistry {
    *
    * @param   {String} name      the name/topic the subscriber was previously registered for
    * @param   {String} msgString the message as string
+   * @param   {Boolean} noDelay flay to disable broadcast delay for message
    * @param   {[SocketWrapper]} socket an optional socket that shouldn't receive the message
    *
    * @public
    * @returns {void}
    */
-  sendToSubscribers (name, msgString, socket) {
+  sendToSubscribers (name, msgString, noDelay, socket) {
     if (!this._subscriptions.has(name)) {
       return
     }
@@ -246,7 +247,7 @@ class SubscriptionRegistry {
 
     // reuse the same timer if already started
     if (!this._delayedBroadcastsTimer) {
-      if (this._delay !== -1) {
+      if (this._delay !== -1 && !noDelay) {
         this._delayedBroadcastsTimer = setTimeout(this._onBroadcastTimeout, this._delay)
       } else {
         this._onBroadcastTimeout()

--- a/test/record/record-handlerSpec.js
+++ b/test/record/record-handlerSpec.js
@@ -463,6 +463,7 @@ describe('record handler handles messages', () => {
     expect(clientA.socket.lastSendMessage).toBe(msg('R|A|D|test+'))
   })
 
+
   it('creates record test', () => {
     clientA.socket.sendMessages = []
     recordHandler.handle(clientA, {
@@ -474,5 +475,38 @@ describe('record handler handles messages', () => {
 
     expect(clientA.socket.sendMessages[0]).not.toContain('MULTIPLE_SUBSCRIPTIONS')
     expect(clientA.socket.lastSendMessage).toBe(msg('R|R|test|0|{}+'))
+  })
+
+  it('creates record deleteEvent', () => {
+    recordHandler.handle(clientA, {
+      raw: msg('R|CR|deleteEvent'),
+      topic: 'R',
+      action: 'CR',
+      data: ['deleteEvent']
+    })
+
+    expect(clientA.socket.lastSendMessage).toBe(msg('R|R|deleteEvent|0|{}+'))
+  })
+
+  it('subscribes record deleteEvent', () => {
+    recordHandler.handle(clientB, {
+      raw: msg('R|CR|deleteEvent'),
+      topic: 'R',
+      action: 'CR',
+      data: ['deleteEvent']
+    })
+
+    expect(clientB.socket.lastSendMessage).toBe(msg('R|R|deleteEvent|0|{}+'))
+  })
+
+  it('deletes record deleteEvent and receives event', () => {
+    recordHandler.handle(clientA, {
+      raw: msg('R|D|deleteEvent'),
+      topic: 'R',
+      action: 'D',
+      data: ['deleteEvent']
+    })
+
+    expect(clientB.socket.lastSendMessage).toBe(msg('R|A|D|deleteEvent+'))
   })
 })

--- a/test/record/record-transitionSpec.js
+++ b/test/record/record-transitionSpec.js
@@ -36,7 +36,7 @@ describe('record transitions', () => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
       recordTransition._recordRequest.onComplete({ _v: 0, _d: {} })
-      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, socketWrapper)
+      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, false, socketWrapper)
       expect(recordHandlerMock._$transitionComplete).toHaveBeenCalledWith('someRecord')
     })
   })
@@ -140,7 +140,7 @@ describe('record transitions', () => {
       expect(options.cache.completedSetOperations).toBe(0)
       const check = setInterval(() => {
         if (options.cache.completedSetOperations === 1) {
-          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, socketWrapper)
+          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, false, socketWrapper)
           expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
           expect(recordTransition._record).toEqual({ _v: 2, _d: { lastname: 'Peterson' } })
           clearInterval(check)
@@ -166,8 +166,8 @@ describe('record transitions', () => {
     it('processes the next step in the queue', (done) => {
       const check = setInterval(() => {
         if (options.cache.completedSetOperations === 2) {
-          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', updateMessage, socketWrapper)
-          expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalledWith('someRecord', patchMessage2, socketWrapper)
+          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', updateMessage, false, socketWrapper)
+          expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalledWith('someRecord', patchMessage2, false, socketWrapper)
           expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
           expect(recordTransition._record).toEqual({ _v: 3, _d: { firstname: 'Lana', lastname: 'Peterson' } })
           clearInterval(check)
@@ -179,7 +179,7 @@ describe('record transitions', () => {
     it('processes the final step in the queue', (done) => {
       const check = setInterval(() => {
         if (options.cache.completedSetOperations === 3) {
-          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage2, socketWrapper)
+          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage2, false, socketWrapper)
           expect(recordHandlerMock._$transitionComplete).toHaveBeenCalled()
           clearInterval(check)
           done()
@@ -220,7 +220,7 @@ describe('record transitions', () => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
       recordTransition._recordRequest.onComplete({ _v: 0, _d: {} })
-      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('no-storage/1', patchMessage, socketWrapper)
+      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('no-storage/1', patchMessage, false, socketWrapper)
       expect(recordHandlerMock._$transitionComplete).toHaveBeenCalledWith('no-storage/1')
     })
 

--- a/test/record/record-write-acknowledgementSpec.js
+++ b/test/record/record-write-acknowledgementSpec.js
@@ -35,7 +35,7 @@ describe('record write acknowledgement', () => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
       recordTransition._recordRequest.onComplete({ _v: 0, _d: {} })
-      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, socketWrapper)
+      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, false, socketWrapper)
       expect(recordHandlerMock._$transitionComplete).toHaveBeenCalledWith('someRecord')
     })
 
@@ -69,7 +69,7 @@ describe('record write acknowledgement', () => {
       expect(recordHandlerMock._$broadcastUpdate).not.toHaveBeenCalled()
       expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
       recordTransition._recordRequest.onComplete({ _v: 0, _d: {} })
-      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, socketWrapper)
+      expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage, false, socketWrapper)
       expect(recordHandlerMock._$transitionComplete).toHaveBeenCalledWith('someRecord')
     })
 
@@ -136,7 +136,7 @@ describe('record write acknowledgement', () => {
     it('processes the next step in the queue', (done) => {
       const check = setInterval(() => {
         if (options.cache.completedSetOperations === 2) {
-          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage2, socketWrapper2)
+          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage2, false, socketWrapper2)
           expect(recordHandlerMock._$transitionComplete).not.toHaveBeenCalled()
           expect(recordTransition._record).toEqual({ _v: 3, _d: { firstname: 'Lana', lastname: 'Kowalski' } })
           clearInterval(check)
@@ -148,7 +148,7 @@ describe('record write acknowledgement', () => {
     it('processes the final step in the queue', (done) => {
       const check = setInterval(() => {
         if (options.cache.completedSetOperations === 3) {
-          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage3, socketWrapper)
+          expect(recordHandlerMock._$broadcastUpdate).toHaveBeenCalledWith('someRecord', patchMessage3, false, socketWrapper)
           expect(recordHandlerMock._$transitionComplete).toHaveBeenCalled()
           clearInterval(check)
           done()

--- a/test/utils/subscription-registrySpec.js
+++ b/test/utils/subscription-registrySpec.js
@@ -65,7 +65,7 @@ describe('subscription-registry manages subscriptions', () => {
   it('doesn\'t send message to sender', () => {
     expect(socketWrapperA.socket.lastSendMessage).toBe(_msg('msg2+'))
     expect(socketWrapperB.socket.lastSendMessage).toBe(_msg('msg2+'))
-    subscriptionRegistry.sendToSubscribers('someName', _msg('msg3+'), socketWrapperA)
+    subscriptionRegistry.sendToSubscribers('someName', _msg('msg3+'), false, socketWrapperA)
     expect(socketWrapperA.socket.lastSendMessage).toBe(_msg('msg2+'))
     expect(socketWrapperB.socket.lastSendMessage).toBe(_msg('msg3+'))
   })


### PR DESCRIPTION
This adds an option in the sendToSubscribers method to override delay. It should be turned on in any case where subscribers may be removed prior to the broadcast of the event.

I ordered the the noDelay argument as third as the socket argument was considered optional. 

This should resolve the case where delete events do not fire.

Referenced Issues:
https://github.com/deepstreamIO/deepstream.io/issues/632
https://github.com/deepstreamIO/deepstream.io/issues/592
https://github.com/deepstreamIO/deepstream.io/issues/533