### PR TITLE
Fix for issue #641

### DIFF
--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -341,6 +341,10 @@ RecordHandler.prototype._update = function (socketWrapper, message) {
     return
   }
 
+  if (this._transitions[recordName] && this._transitions[recordName].isDestroyed) {
+    delete this._transitions[recordName];
+  }
+
   if (this._transitions[recordName] && this._transitions[recordName].hasVersion(version)) {
     this._transitions[recordName].sendVersionExists({ message, version, sender: socketWrapper })
     return


### PR DESCRIPTION
This will fix this issue: https://github.com/deepstreamIO/deepstream.io/issues/641. Creating a unit test that simulates the scenario in which the cache or storage later returns an error isn't all straightforward. 

If you need one for this case, I can give it a shot.