### PR TITLE
Select remote RPC server uniformly

### DIFF
--- a/src/rpc/rpc-handler.js
+++ b/src/rpc/rpc-handler.js
@@ -221,7 +221,7 @@ module.exports = class RpcHandler {
     const rpcData = this._rpcs.get(correlationId)
 
     const servers = this._subscriptionRegistry.getAllRemoteServers(rpcName)
-    const server = servers[Math.round(Math.random() * (servers.length - 1))]
+    const server = servers[utils.getRandomIntInRange(0, servers.length)]
 
     if (server) {
       const rpcProxy = new RpcProxy(this._options, C.TOPIC.PRIVATE + server, rpcName, correlationId)


### PR DESCRIPTION
Fixes #725
Servers were being selected non-uniformly due to misuse of `Math.round`.