### PR TITLE
handlePermissionStrategy failing on path

### DIFF
--- a/src/config/config-initialiser.js
+++ b/src/config/config-initialiser.js
@@ -318,7 +318,7 @@ function handlePermissionStrategy (config) {
     config.permission.options = {}
   }
 
-  if (!permissionStrategies[config.permission.type] && !config.permission.path) {
+  if (!permissionStrategies[config.permission.type] && !config.permission.options.path) {
     throw new Error(`Unknown permission type ${config.permission.type}`)
   }
 


### PR DESCRIPTION
When setting up a custom permission handler, the logic was looking for the path at: `permissions.path` and not `permissions.options.path` where it is defined in the sample config.yml file.