### PR TITLE
handle JSON paths into numeric values

### DIFF
--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -19,16 +19,8 @@ function setValue (root, path, value) {
   for (i = 0; i < tokens.length - 1; i++) {
     const token = tokens[i]
 
-    if (node[token] !== undefined) {
-      if (typeof node[token] !== 'object') {
-        if (typeof tokens[i + 1] === 'number') {
-          node = node[token] = []
-        } else {
-          node = node[token] = {}
-        }
-      } else {
-        node = node[token]
-      }
+    if (node[token] !== undefined && typeof node[token] === 'object') {
+      node = node[token]
     } else if (typeof tokens[i + 1] === 'number') {
       node = node[token] = []
     } else {

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -18,9 +18,18 @@ function setValue (root, path, value) {
   let i
   for (i = 0; i < tokens.length - 1; i++) {
     const token = tokens[i]
+
     if (node[token] !== undefined) {
-      node = node[token]
-    } else if (tokens[i + 1] !== undefined && typeof tokens[i + 1] === 'number') {
+      if (typeof node[token] !== 'object') {
+        if (typeof tokens[i + 1] === 'number') {
+          node = node[token] = []
+        } else {
+          node = node[token] = {}
+        }
+      } else {
+        node = node[token]
+      }
+    } else if (typeof tokens[i + 1] === 'number') {
       node = node[token] = []
     } else {
       node = node[token] = {}

--- a/test/record/json-pathSpec.js
+++ b/test/record/json-pathSpec.js
@@ -290,4 +290,37 @@ describe('objects are created from paths and their value is set correctly', () =
     })
   })
 
+  it('handles .xyz paths into non-objects', () => {
+    const record = { animals: 3 }
+    jsonPath.setValue(record, 'animals.name', 'Emu')
+
+    expect(record).toEqual({
+      animals: {
+        name: 'Emu'
+      }
+    })
+  })
+
+  it('handles .xyz paths through non-objects', () => {
+    const record = { animals: 3 }
+    jsonPath.setValue(record, 'animals.name.length', 7)
+
+    expect(record).toEqual({
+      animals: {
+        name: {
+          length: 7
+        }
+      }
+    })
+  })
+
+  it('handles [0] paths into non-objects', () => {
+    const record = { animals: 3 }
+    jsonPath.setValue(record, 'animals[0]', 7)
+
+    expect(record).toEqual({
+      animals: [7]
+    })
+  })
+
 })


### PR DESCRIPTION
Since the recent refactor, json paths such as `foo.bar` into a record
with a value like { "foo": 3 } would crash the server with a TypeError.

This commit fixes that, and adds some unit tests.