### PR TITLE
feat: enable multiple connection endpoints to be configured at once

### DIFF
--- a/src/config/config-initialiser.js
+++ b/src/config/config-initialiser.js
@@ -201,9 +201,6 @@ function handleConnectionEndpoints (config) {
   if (!config.connectionEndpoints || Object.keys(config.connectionEndpoints).length === 0) {
     throw new Error('No connection endpoints configured')
   }
-  if (Object.keys(config.connectionEndpoints).length > 1) {
-    throw new Error('Currently only one connection endpoint may be configured.')
-  }
   const connectionEndpoints = []
   for (const connectionType in config.connectionEndpoints) {
     const plugin = config.connectionEndpoints[connectionType]

--- a/src/utils/dependency-initialiser.js
+++ b/src/utils/dependency-initialiser.js
@@ -15,11 +15,11 @@ const EventEmitter = require('events').EventEmitter
  *
  * @constructor
  */
-const DependencyInitialiser = function (deepstream, options, name) {
+const DependencyInitialiser = function (deepstream, options, dependency, name) {
   this.isReady = false
 
   this._options = options
-  this._dependency = options[name]
+  this._dependency = dependency
   this._name = name
   this._timeout = null
 

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -43,8 +43,7 @@ describe('connection endpoint', () => {
     authenticationHandlerMock.reset()
 
     connectionEndpoint = new ConnectionEndpoint(options, () => {})
-    options.connectionEndpoint = connectionEndpoint
-    const depInit = new DependencyInitialiser(mockDs, options, 'connectionEndpoint')
+    const depInit = new DependencyInitialiser(mockDs, options, connectionEndpoint, 'connectionEndpoint')
     depInit.on('ready', () => {
       connectionEndpoint.onMessages()
       connectionEndpoint.onMessages = function (socket, messages) {
@@ -402,8 +401,7 @@ describe('connection endpoint doesn\'t log credentials if logInvalidAuthData is 
     const options2 = Object.assign({}, options)
     options2.logInvalidAuthData = false
     const connectionEndpoint2 = new ConnectionEndpoint(options2, () => {})
-    options2.connectionEndpoint = connectionEndpoint2
-    const depInit = new DependencyInitialiser({ _options: options2 }, options2, 'connectionEndpoint')
+    const depInit = new DependencyInitialiser({ _options: options2 }, options2, connectionEndpoint2, 'connectionEndpoint')
     depInit.on('ready', () => {
       connectionEndpoint2._server._simulateUpgrade(new SocketMock())
       socketWrapperMock = uwsMock.simulateConnection()

--- a/test/message/permission-handlerSpec.js
+++ b/test/message/permission-handlerSpec.js
@@ -51,15 +51,16 @@ const mockDs = {
 
 describe('permissionHandler passes additional user meta data', () => {
   let socketWrapperMock
+  let connectionEndpoint
 
   beforeAll((done) => {
-    options.connectionEndpoint = new ConnectionEndpoint(options)
-    const depInit = new DependencyInitialiser(mockDs, options, 'connectionEndpoint')
+    connectionEndpoint = new ConnectionEndpoint(options)
+    const depInit = new DependencyInitialiser(mockDs, options, connectionEndpoint, 'connectionEndpoint')
     depInit.on('ready', () => {
-      options.connectionEndpoint.onMessages = function (socket, messages) {
+      connectionEndpoint.onMessages = function (socket, messages) {
         lastAuthenticatedMessage = messages[messages.length - 1]
       }
-      options.connectionEndpoint._server._simulateUpgrade(new SocketMock())
+      connectionEndpoint._server._simulateUpgrade(new SocketMock())
       socketWrapperMock = uwsMock.simulateConnection()
       uwsMock._messageHandler(_msg('C|CHR|localhost:6021+'), socketWrapperMock)
 
@@ -76,9 +77,9 @@ describe('permissionHandler passes additional user meta data', () => {
   })
 
   it('sends a record read message', () => {
-    spyOn(options.connectionEndpoint, 'onMessages')
+    spyOn(connectionEndpoint, 'onMessages')
     uwsMock._messageHandler(_msg('R|CR|someRecord+'), socketWrapperMock)
-    expect(options.connectionEndpoint.onMessages).toHaveBeenCalled()
-    expect(options.connectionEndpoint.onMessages.calls.mostRecent().args[0].authData).toEqual({ role: 'admin' })
+    expect(connectionEndpoint.onMessages).toHaveBeenCalled()
+    expect(connectionEndpoint.onMessages.calls.mostRecent().args[0].authData).toEqual({ role: 'admin' })
   })
 })

--- a/test/utils/dependency-initialiserSpec.js
+++ b/test/utils/dependency-initialiserSpec.js
@@ -29,7 +29,7 @@ describe('dependency-initialiser', () => {
 
   it('selects the correct plugin', () => {
     options.logger.lastLogEvent = null
-    dependencyBInitialiser = new DependencyInitialiser({}, options, 'pluginB')
+    dependencyBInitialiser = new DependencyInitialiser({}, options, options.pluginB, 'pluginB')
     expect(dependencyBInitialiser.getDependency().name).toBe('B')
     expect(options.logger.lastLogEvent).toBe(null)
   })
@@ -51,7 +51,7 @@ describe('dependency-initialiser', () => {
     const dsMock = { is: 'deepstream' }
     const setDsSpy = options.pluginC.setDeepstream = jasmine.createSpy('setDeepstream')
     options.pluginC.isReady = true
-    new DependencyInitialiser(dsMock, options, 'pluginC')
+    new DependencyInitialiser(dsMock, options, options.pluginC, 'pluginC')
     expect(setDsSpy).toHaveBeenCalledWith(dsMock)
   })
 
@@ -63,7 +63,7 @@ describe('dependency-initialiser', () => {
       options.pluginC.setReady()
     }
     options.pluginC.isReady = false
-    new DependencyInitialiser(dsMock, options, 'pluginC')
+    new DependencyInitialiser(dsMock, options, options.pluginC, 'pluginC')
     expect(options.pluginC._deepstream).toBe(dsMock)
   })
 })
@@ -86,7 +86,7 @@ describe('encounters timeouts and errors during dependency initialisations', () 
   })
 
   it('creates a depdendency initialiser and doesnt initialise a plugin in time', (next) => {
-    dependencyInitialiser = new DependencyInitialiser({}, options, 'plugin')
+    dependencyInitialiser = new DependencyInitialiser({}, options, options.plugin, 'plugin')
     dependencyInitialiser.on('ready', onReady)
     expect(options.plugin.isReady).toBe(false)
     process.removeAllListeners('uncaughtException')
@@ -104,7 +104,7 @@ describe('encounters timeouts and errors during dependency initialisations', () 
       expect(log).toHaveBeenCalledWith('Error while initialising plugin: something went wrong')
       next()
     })
-    dependencyInitialiser = new DependencyInitialiser({}, options, 'plugin')
+    dependencyInitialiser = new DependencyInitialiser({}, options, options.plugin, 'plugin')
     dependencyInitialiser.on('ready', onReady)
     options.logger.isReady = false
     try {


### PR DESCRIPTION
Note: it is not currently possible to configure more than one
subscription registry, so only one connection enpoint can be
configured to allow:
- providing an rpc
- subscribing to an event
- subscribing to record updates
- listening
- subscribing to presence

Configuring more than one plugin with any of these facilities will lead
to undefined behaviour.