### PR TITLE
Ability for custom permission handler to revoke a granted permission dynamically.

### DIFF
--- a/src/event/event-handler.js
+++ b/src/event/event-handler.js
@@ -33,9 +33,14 @@ module.exports = class EventHandler {
    * @public
    * @returns {void}
    */
-  handle (socket, message) {
+  handle (socket, message, return_revoker) {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._addSubscriber(socket, message)
+      if (return_revoker) {
+        return_revoker(()=>{
+          this._removeSubscriber(socket, message);
+        })
+      }
     } else if (message.action === C.ACTIONS.UNSUBSCRIBE) {
       this._removeSubscriber(socket, message)
     } else if (message.action === C.ACTIONS.EVENT) {

--- a/src/event/event-handler.js
+++ b/src/event/event-handler.js
@@ -37,8 +37,8 @@ module.exports = class EventHandler {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._addSubscriber(socket, message)
       if (returnRevoker) {
-        returnRevoker(()=>{
-          this._removeSubscriber(socket, message);
+        returnRevoker(() => {
+          this._removeSubscriber(socket, message)
         })
       }
     } else if (message.action === C.ACTIONS.UNSUBSCRIBE) {

--- a/src/event/event-handler.js
+++ b/src/event/event-handler.js
@@ -33,11 +33,11 @@ module.exports = class EventHandler {
    * @public
    * @returns {void}
    */
-  handle (socket, message, return_revoker) {
+  handle (socket, message, returnRevoker) {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._addSubscriber(socket, message)
-      if (return_revoker) {
-        return_revoker(()=>{
+      if (returnRevoker) {
+        returnRevoker(()=>{
           this._removeSubscriber(socket, message);
         })
       }

--- a/src/message/message-distributor.js
+++ b/src/message/message-distributor.js
@@ -24,7 +24,7 @@ module.exports = class MessageDistributor {
    * @public
    * @returns {void}
    */
-  distribute (socketWrapper, message) {
+  distribute (socketWrapper, message, return_revoker) {
     if (this._callbacks[message.topic] === undefined) {
       this._options.logger.warn(C.EVENT.UNKNOWN_TOPIC, message.topic)
       socketWrapper.sendError(C.TOPIC.ERROR, C.EVENT.UNKNOWN_TOPIC, message.topic)
@@ -35,7 +35,7 @@ module.exports = class MessageDistributor {
     socketWrapper.emit(message.topic, message)
 
     if (message.isCompleted !== true) {
-      this._callbacks[message.topic](socketWrapper, message)
+      this._callbacks[message.topic](socketWrapper, message, return_revoker)
     }
   }
 

--- a/src/message/message-distributor.js
+++ b/src/message/message-distributor.js
@@ -24,7 +24,7 @@ module.exports = class MessageDistributor {
    * @public
    * @returns {void}
    */
-  distribute (socketWrapper, message, return_revoker) {
+  distribute (socketWrapper, message, returnRevoker) {
     if (this._callbacks[message.topic] === undefined) {
       this._options.logger.warn(C.EVENT.UNKNOWN_TOPIC, message.topic)
       socketWrapper.sendError(C.TOPIC.ERROR, C.EVENT.UNKNOWN_TOPIC, message.topic)
@@ -35,7 +35,7 @@ module.exports = class MessageDistributor {
     socketWrapper.emit(message.topic, message)
 
     if (message.isCompleted !== true) {
-      this._callbacks[message.topic](socketWrapper, message, return_revoker)
+      this._callbacks[message.topic](socketWrapper, message, returnRevoker)
     }
   }
 

--- a/src/message/message-processor.js
+++ b/src/message/message-processor.js
@@ -85,7 +85,7 @@ module.exports = class MessageProcessor {
    *
    * @returns {void}
    */
-  _onPermissionResponse (socketWrapper, message, error, result, return_revoker) {
+  _onPermissionResponse (socketWrapper, message, error, result, returnRevoker) {
     if (error !== null) {
       this._options.logger.warn(C.EVENT.MESSAGE_PERMISSION_ERROR, error.toString())
       socketWrapper.sendError(
@@ -105,7 +105,7 @@ module.exports = class MessageProcessor {
       return
     }
 
-    this.onAuthenticatedMessage(socketWrapper, message, return_revoker)
+    this.onAuthenticatedMessage(socketWrapper, message, returnRevoker)
   }
 
   /**

--- a/src/message/message-processor.js
+++ b/src/message/message-processor.js
@@ -85,7 +85,7 @@ module.exports = class MessageProcessor {
    *
    * @returns {void}
    */
-  _onPermissionResponse (socketWrapper, message, error, result) {
+  _onPermissionResponse (socketWrapper, message, error, result, return_revoker) {
     if (error !== null) {
       this._options.logger.warn(C.EVENT.MESSAGE_PERMISSION_ERROR, error.toString())
       socketWrapper.sendError(
@@ -105,7 +105,7 @@ module.exports = class MessageProcessor {
       return
     }
 
-    this.onAuthenticatedMessage(socketWrapper, message)
+    this.onAuthenticatedMessage(socketWrapper, message, return_revoker)
   }
 
   /**

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -41,7 +41,7 @@ module.exports = class RecordHandler {
  * @public
  * @returns {void}
  */
-  handle (socketWrapper, message, return_revoker) {
+  handle (socketWrapper, message, returnRevoker) {
   /*
    * All messages have to provide at least the name of the record they relate to
    * or a pattern in case of listen
@@ -57,8 +57,8 @@ module.exports = class RecordHandler {
      * Creates the record if it doesn't exist
      */
       this._createOrRead(socketWrapper, message)
-      if (return_revoker) {
-        return_revoker(() => {
+      if (returnRevoker) {
+        returnRevoker(() => {
           this._subscriptionRegistry.unsubscribe(message.data[0], socketWrapper)
         });
       }

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -41,7 +41,7 @@ module.exports = class RecordHandler {
  * @public
  * @returns {void}
  */
-  handle (socketWrapper, message) {
+  handle (socketWrapper, message, return_revoker) {
   /*
    * All messages have to provide at least the name of the record they relate to
    * or a pattern in case of listen
@@ -57,6 +57,11 @@ module.exports = class RecordHandler {
      * Creates the record if it doesn't exist
      */
       this._createOrRead(socketWrapper, message)
+      if (return_revoker) {
+        return_revoker(() => {
+          this._subscriptionRegistry.unsubscribe(message.data[0], socketWrapper)
+        });
+      }
     } else if (message.action === C.ACTIONS.CREATEANDUPDATE) {
     /*
      * Allows updates to the record without being subscribed, creates

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -60,7 +60,7 @@ module.exports = class RecordHandler {
       if (returnRevoker) {
         returnRevoker(() => {
           this._subscriptionRegistry.unsubscribe(message.data[0], socketWrapper)
-        });
+        })
       }
     } else if (message.action === C.ACTIONS.CREATEANDUPDATE) {
     /*

--- a/src/rpc/rpc-handler.js
+++ b/src/rpc/rpc-handler.js
@@ -36,11 +36,11 @@ module.exports = class RpcHandler {
   * @public
   * @returns {void}
   */
-  handle (socketWrapper, message, return_revoker) {
+  handle (socketWrapper, message, returnRevoker) {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._registerProvider(socketWrapper, message)
-      if (return_revoker) {
-        return_revoker(()=>{
+      if (returnRevoker) {
+        returnRevoker(()=>{
           this._unregisterProvider(socketWrapper, message)
         })
       }

--- a/src/rpc/rpc-handler.js
+++ b/src/rpc/rpc-handler.js
@@ -36,9 +36,14 @@ module.exports = class RpcHandler {
   * @public
   * @returns {void}
   */
-  handle (socketWrapper, message) {
+  handle (socketWrapper, message, return_revoker) {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._registerProvider(socketWrapper, message)
+      if (return_revoker) {
+        return_revoker(()=>{
+          this._unregisterProvider(socketWrapper, message)
+        })
+      }
     } else if (message.action === C.ACTIONS.UNSUBSCRIBE) {
       this._unregisterProvider(socketWrapper, message)
     } else if (message.action === C.ACTIONS.REQUEST) {

--- a/src/rpc/rpc-handler.js
+++ b/src/rpc/rpc-handler.js
@@ -40,7 +40,7 @@ module.exports = class RpcHandler {
     if (message.action === C.ACTIONS.SUBSCRIBE) {
       this._registerProvider(socketWrapper, message)
       if (returnRevoker) {
-        returnRevoker(()=>{
+        returnRevoker(() => {
           this._unregisterProvider(socketWrapper, message)
         })
       }


### PR DESCRIPTION
Here, after every permitted operation (record subscription, event subscription, RPC provider subscription), the respective operation handler sends back a function to the permission handler which can be called at any later time to revoke the same permission through emulating an "undo" or doing the reverse operation (record unsubscribe, event unsubscribe, RPC provider unsubscribe), as if it originated, say, from the client.

An example permission handler making use of such a feature is: (***conceptual pseudo code***)
```js
let main_server = new DeepstreamServer({port: 6020, allowRemoteConnections: true});
let helper_server = new DeepstreamServer({port: 6021, allowRemoteConnections: false});

helper_server.start();
helper_server.client = new DeepstreamClient({port: 6021});
await helper_server.login();

main_server.set('permissionHandler', {
  isReady: true,
  canPerformAction: function(username, message, callback, authData) {
   let msg = decode_message(message);
    if (msg.type === 'subscribe to record data') {
      let permission_record_name = 'permission/'+msg.record.type //eg: 'permission/user'
      let rule = await helper_server.client.getRecord(permission_record_name).whenReady;
      let user = await helper_server.client.getRecord('user/'+username).whenReady;
      let result = calculate_permission(rule, user, data); //data is data being read.
      if (result) {
        callback(null, true, (revoke) => { //grant permission;
            rule.subscribe((new_rule) => {
              if (!calculate_permission(new_rule, user, data)) {
                revoke();
                rule.discard();
              }
            });
        }); 
      } else callback(null, false); //reject permission.
    }
  }
}); 

main_server.start();
```