### PR TITLE
Use https github url for protocol/binary submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/deepstreamIO/deepstream.io-e2e.git
 [submodule "protocol/binary"]
 	path = protocol/binary
-	url = git@github.com:deepstreamIO/urp-js
+	url = https://github.com/deepstreamIO/urp-js.git


### PR DESCRIPTION
This PR updates the original url for the `protocol/binary` git submodule to use github https url.

I'm not totally familiar with the best practices for git submodules but the original url (`git@github.com:deepstreamIO/urp-js`) did not work when I tried update the submodules on my local clone.  The updated url works perfectly using `git submodule update --init protocol/binary`.