### PR TITLE
locked down uws version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deepstream.io",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1161,14 +1161,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "deepstream.io-service": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/deepstream.io-service/-/deepstream.io-service-0.1.5.tgz",
-      "integrity": "sha1-Q5icFFzLQAhCGQY4Cn5rpN8Tc6I=",
-      "requires": {
-        "colors": "^1.1.2"
-      }
     },
     "define-properties": {
       "version": "1.1.2",
@@ -4618,9 +4610,9 @@
       "dev": true
     },
     "uws": {
-      "version": "10.148.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-10.148.0.tgz",
-      "integrity": "sha512-aJpFgMMyxubiE/ll4nj9nWoQbv0HzZZDWXfwyu78nuFObX0Zoyv3TWjkqKPQ1vb2sMPZoz67tri7QNE6dybNmQ=="
+      "version": "10.148.2",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-10.148.2.tgz",
+      "integrity": "sha1-8BZSoLS7lByxi7emJI14D9AVAkU="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "needle": "^2.0.0",
     "original-fs": "^1.0.0",
-    "uws": "^9"
+    "uws": "^10.148.2"
   },
   "devDependencies": {
     "async": "^2.5.0",


### PR DESCRIPTION
uws maintainer has published an empty package as latest on npm, breaking this build.
This commit locks the version to latest **_working_** one.

More;
https://www.reddit.com/r/node/comments/97kn8r/the_uws_npm_deprecation_response/