### PR TITLE
Add implementation and test for write ack problem

### DIFF
--- a/src/record/record-transition.ts
+++ b/src/record/record-transition.ts
@@ -368,22 +368,16 @@ export default class RecordTransition {
     if (error) {
       this.onFatalError(error)
     } else if (this.isDestroyed === false) {
-      // // Get values that should not be broadcast
-      const { isWriteAck, correlationId } = this.currentStep.message
+      const copiedMessage = { ...this.currentStep.message, isWriteAck: false }
+      delete copiedMessage.correlationId
 
-      // // Delete values that should not be broadcast
-      this.currentStep.message.isWriteAck = false
-      this.currentStep.message.correlationId = undefined
       this.recordHandler.broadcastUpdate(
         this.name,
-        this.currentStep.message,
+        copiedMessage,
         false,
         this.currentStep.sender,
       )
 
-      // Restore the message for other callers to use
-      this.currentStep.message.isWriteAck = isWriteAck
-      this.currentStep.message.correlationId = correlationId
       this.next()
     } else if (this.steps.length === 0 && this.pendingCacheWrites === 0 && this.pendingStorageWrites === 0) {
       this.destroy(null)

--- a/src/record/record-transition.ts
+++ b/src/record/record-transition.ts
@@ -368,8 +368,12 @@ export default class RecordTransition {
     if (error) {
       this.onFatalError(error)
     } else if (this.isDestroyed === false) {
+      // // Get values that should not be broadcast
+      const { isWriteAck, correlationId } = this.currentStep.message
+
+      // // Delete values that should not be broadcast
       this.currentStep.message.isWriteAck = false
-      delete this.currentStep.message.correlationId
+      this.currentStep.message.correlationId = undefined
       this.recordHandler.broadcastUpdate(
         this.name,
         this.currentStep.message,
@@ -377,6 +381,9 @@ export default class RecordTransition {
         this.currentStep.sender,
       )
 
+      // Restore the message for other callers to use
+      this.currentStep.message.isWriteAck = isWriteAck
+      this.currentStep.message.correlationId = correlationId
       this.next()
     } else if (this.steps.length === 0 && this.pendingCacheWrites === 0 && this.pendingStorageWrites === 0) {
       this.destroy(null)

--- a/test/record/record-transitionSpec.ts
+++ b/test/record/record-transitionSpec.ts
@@ -32,7 +32,7 @@ describe('RecordTransition', () => {
     testMocks.recordHandlerMock.verify()
   })
 
-  it('sends update for both cache and storage', async () => {
+  it('sends write acknowledgement with sync cache and async storage', async () => {
     const message: C.RecordWriteMessage = {
       topic: C.TOPIC.RECORD,
       action: C.RECORD_ACTIONS.UPDATE,
@@ -51,8 +51,6 @@ describe('RecordTransition', () => {
     services.cache.nextOperationWillBeSuccessful = true
     services.cache.nextOperationWillBeSynchronous = true
 
-    client.socketWrapperMock.parseData = () => {}
-
     client.socketWrapperMock
       .expects('sendMessage')
       .once()
@@ -65,7 +63,7 @@ describe('RecordTransition', () => {
 
     recordTransition.add(client.socketWrapper, message, true)
     // Wait for the async callback to fire
-    await new Promise((resolve, reject) => setTimeout(resolve, 50))
+    await new Promise((resolve, reject) => setTimeout(resolve, 60))
   })
 })
 


### PR DESCRIPTION
We noticed that there was a problem when running setDataWithAck from the client and traced the problem here. The main problem is that there are two different callbacks that both use the same message, but one of the callbacks change the message, making it fault in the second one.

First `this.services.storage.set(...)` is called [here](https://github.com/deepstreamIO/deepstream.io/blob/v4/src/record/record-transition.ts#L294), this may be an async operation. This function in turn calls `this.onStorageSetResponse(...)` when it is finished, found [here](https://github.com/deepstreamIO/deepstream.io/blob/v4/src/record/record-transition.ts#L389).

Second, `this.services.cache.set(...)` is called [here](https://github.com/deepstreamIO/deepstream.io/blob/v4/src/record/record-transition.ts#L303), with a callback to `this.onCacheSetResponse(...)` when it is finished, found [here](https://github.com/deepstreamIO/deepstream.io/blob/v4/src/record/record-transition.ts#L364).

If the call to `onStorageSetResponse()` is called after `onCacheSetResponse()` then there is a possibility that `correlationId` and `isWriteAck` will have changed, because of [here](https://github.com/deepstreamIO/deepstream.io/blob/v4/src/record/record-transition.ts#L372), causing `onStorageSetResponse()` to not properly acknowledge the original message.

I solved it with this implementation and added a test for it, emulating an async `storage` and sync `cache` which causes the fault to trigger.