### PR TITLE
Fixed unsubscribing from presence handler with old protocol format

### DIFF
--- a/src/presence/presence-handler.js
+++ b/src/presence/presence-handler.js
@@ -13,6 +13,7 @@ function parseUserNames (data, socketWrapper) {
     (data.length === 1 && (
     data[0] === C.ACTIONS.QUERY ||
     data[0] === C.ACTIONS.SUBSCRIBE ||
+    data[0] === C.ACTIONS.UNSUBSCRIBE ||
     data[0] === C.TOPIC.PRESENCE)
   )) {
     return [EVERYONE]


### PR DESCRIPTION
Unsubscribing from presence handler without specifying dedicated users (old protocol format) led to an error (INVALID_PRESENCE_USERS: 'users are required to be a json array of usernames'). This pull request fixes the issue by applying the same "backwards compatibility" routine as for subscriptions in the old protocol format.