### PR TITLE
Moving null checker before reference

### DIFF
--- a/src/message/message-processor.js
+++ b/src/message/message-processor.js
@@ -50,17 +50,23 @@ module.exports = class MessageProcessor {
     const length = parsedMessages.length
     for (let i = 0; i < length; i++) {
       parsedMessage = parsedMessages[i]
-      
-      if (parsedMessage === null ||
-        !parsedMessage.action ||
-        !parsedMessage.topic ||
-        !parsedMessage.data) {
+
+      // Checking for a null parse message before referencing
+      if (parsedMessage === null) {
         this._options.logger.warn(C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
         socketWrapper.sendError(C.TOPIC.ERROR, C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
         continue
       }
-      
+
       if (parsedMessage.topic === C.TOPIC.CONNECTION && parsedMessage.action === C.ACTIONS.PONG) {
+        continue
+      }
+
+      if (!parsedMessage.action ||
+        !parsedMessage.topic ||
+        !parsedMessage.data) {
+        this._options.logger.warn(C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
+        socketWrapper.sendError(C.TOPIC.ERROR, C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
         continue
       }
 

--- a/src/message/message-processor.js
+++ b/src/message/message-processor.js
@@ -50,17 +50,17 @@ module.exports = class MessageProcessor {
     const length = parsedMessages.length
     for (let i = 0; i < length; i++) {
       parsedMessage = parsedMessages[i]
-
-      if (parsedMessage.topic === C.TOPIC.CONNECTION && parsedMessage.action === C.ACTIONS.PONG) {
-        continue
-      }
-
+      
       if (parsedMessage === null ||
         !parsedMessage.action ||
         !parsedMessage.topic ||
         !parsedMessage.data) {
         this._options.logger.warn(C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
         socketWrapper.sendError(C.TOPIC.ERROR, C.EVENT.MESSAGE_PARSE_ERROR, parsedMessage)
+        continue
+      }
+      
+      if (parsedMessage.topic === C.TOPIC.CONNECTION && parsedMessage.action === C.ACTIONS.PONG) {
         continue
       }
 


### PR DESCRIPTION
Currently `parsedMessage` is being referenced before it is being checked for NULL. This can lead to errors, as mentioned here: https://github.com/deepstreamIO/deepstream.io/issues/924.

This PR fixes the issue by moving the check for null before the reference, in order to log any errors and fail gracefully.