### PR TITLE
Fix for iterating over headers

### DIFF
--- a/src/message/uws/connection-endpoint.ts
+++ b/src/message/uws/connection-endpoint.ts
@@ -8,6 +8,7 @@ import * as fileUtils from '../../config/file-utils'
 import * as binaryMessageBuilder from '../../../binary-protocol/src/message-builder'
 import * as binaryMessageParser from '../../../binary-protocol/src/message-parser'
 import {createUWSSocketWrapper} from './socket-wrapper-factory'
+import {isIterable} from "../../utils/utils";
 
 /**
  * This is the frontmost class of deepstream's message pipeline. It receives
@@ -162,6 +163,7 @@ export default class UWSConnectionEndpoint extends ConnectionEndpoint {
 
   public static getHeaders (desiredHeaders, req) {
     const headers = {}
+    if (!isIterable(desiredHeaders)) return headers
     for (const wantedHeader of desiredHeaders) {
       headers[wantedHeader] = req.getHeader(wantedHeader)
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -57,6 +57,16 @@ export let isOfType = function (input: any, expectedType: string): boolean {
 }
 
 /**
+ * Returns whether the input is iterable or not
+ */
+export let isIterable = function (input: any): boolean {
+    if (input == null) {
+        return false;
+    }
+    return typeof input[Symbol.iterator] === 'function';
+}
+
+/**
  * Takes a map and validates it against a basic
  * json schema in the form { key: type }
  * @returns {Boolean|Error}


### PR DESCRIPTION
I was encountering a bug in v4.0.0-rc.6 where desiredHeaders passed to getHeaders in uws/connection-endpoint.ts can be undefined, causing a crash when it was attempted to iterate over it. This fix adds a function in utilities to test for null and iterability before proceeding with iteration.