### PR TITLE
[fix] set header on options request when all origins are allowed

### DIFF
--- a/src/message/http/server.js
+++ b/src/message/http/server.js
@@ -277,7 +277,9 @@ module.exports = class Server extends EventEmitter {
         return
       }
     }
-
+    if (this._config.allowAllOrigins) {
+      response.writeHeader('Access-Control-Allow-Origin', '*')
+    }
     response.writeHeader('Access-Control-Allow-Methods', this._methodsStr)
     response.writeHeader('Access-Control-Allow-Headers', this._headersStr)
     Server._terminateResponse(response, HTTPStatus.OK, 'OK')


### PR DESCRIPTION
Hi! When upgrading to the latest release started getting CORS errors. When the client makes an option request, if allowAllOrigins is true, the 'Access-Control-Allow-Origin' header was not being set. 