### PR TITLE
generate declaration (.d.ts) files during build

### DIFF
--- a/bin/deepstream-cluster.ts
+++ b/bin/deepstream-cluster.ts
@@ -1,7 +1,13 @@
 // @ts-ignore
-import { Command } from 'commander'
+import * as commander from 'commander'
 import * as cluster from 'cluster'
 import { EVENT } from '../ds-types/src/index'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const command = (program: Command) => {
   program

--- a/bin/deepstream-daemon.ts
+++ b/bin/deepstream-daemon.ts
@@ -1,6 +1,12 @@
 // @ts-ignore
 import * as dsDaemon from 'deepstream.io-service/src/daemon'
-import { Command } from 'commander'
+import * as commander from 'commander'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const daemon = (program: Command) => {
   program

--- a/bin/deepstream-hash.ts
+++ b/bin/deepstream-hash.ts
@@ -1,6 +1,12 @@
 import * as jsYamlLoader from '../src/config/js-yaml-loader'
-import { Command } from 'commander'
+import * as commander from 'commander'
 import { FileBasedAuthentication } from '../src/services/authentication/file/file-based-authentication'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const hash = (program: Command) => {
   program

--- a/bin/deepstream-info.ts
+++ b/bin/deepstream-info.ts
@@ -3,7 +3,13 @@ import * as path from 'path'
 import * as os from 'os'
 import * as glob from 'glob'
 import * as jsYamlLoader from '../src/config/js-yaml-loader'
-import { Command } from 'commander'
+import * as commander from 'commander'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const info = (program: Command) => {
   program

--- a/bin/deepstream-install.ts
+++ b/bin/deepstream-install.ts
@@ -1,6 +1,12 @@
 import { installer } from '../src/utils/installer'
 import * as jsYamlLoader from '../src/config/js-yaml-loader'
-import { Command } from 'commander'
+import * as commander from 'commander'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const install = (program: Command) => {
   program

--- a/bin/deepstream-service.ts
+++ b/bin/deepstream-service.ts
@@ -1,6 +1,12 @@
 // @ts-ignore
 import * as dsService from 'deepstream.io-service'
-import { Command } from 'commander'
+import * as commander from 'commander'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const service = (program: Command) => {
   program

--- a/bin/deepstream-start.ts
+++ b/bin/deepstream-start.ts
@@ -1,5 +1,11 @@
-import { Command } from 'commander'
+import * as commander from 'commander'
 import { EVENT } from '../ds-types/src/index'
+
+// work-around for:
+// TS4023: Exported variable 'command' has or is using name 'local.Command'
+// from external module "node_modules/commander/typings/index" but cannot be named.
+// tslint:disable-next-line: no-empty-interface
+export interface Command extends commander.Command { }
 
 export const start = (program: Command) => {
   program

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2018",
     "module": "commonjs",
     "outDir": "dist",
+    "declaration": true,
     "sourceMap": true,
     "allowJs": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
Added
`"declaration": true`
to tsconfig.json so that .d.ts files are generated during build.

I had to work around a compile error that occurs only when building with declarations enabled. All of the files in bin/ would fail with
```
TS4023: Exported variable '...' has or is using name 'local.Command'
from external module "node_modules/commander/typings/index" but cannot be named.
```

The only work-around I could find was to introduce an empty interface that extends the "Command" type.