### PR TITLE
fix: allow empty password for mqtt endpoint when authentication is not enabled

### DIFF
--- a/src/connection-endpoint/mqtt/connection-endpoint.ts
+++ b/src/connection-endpoint/mqtt/connection-endpoint.ts
@@ -57,7 +57,7 @@ export class MQTTConnectionEndpoint extends ConnectionEndpoint {
           action: AUTH_ACTION.REQUEST,
           parsedData: {
             username: packet.username,
-            password: packet.password.toString()
+            password: packet.password && packet.password.toString()
           }
         }])
       })


### PR DESCRIPTION
fixes #1003 