### PR TITLE
load permissions from file when config is not yaml file

### DIFF
--- a/src/config/config-initialiser.spec.ts
+++ b/src/config/config-initialiser.spec.ts
@@ -185,7 +185,7 @@ describe('config-initializer', () => {
       config.permission = {
         type: 'config',
         options: {
-          path: './basic-permission-config.json'
+          path: './test-e2e/config/permissions-complex.json'
         }
       }
       const result = configInitialiser.initialize(new EventEmitter(), config)

--- a/src/config/config-initialiser.ts
+++ b/src/config/config-initialiser.ts
@@ -388,6 +388,10 @@ function handlePermissionStrategies (config: DeepstreamConfig, services: Deepstr
       throw new Error(`unable to resolve plugin ${permission.name || permission.path}`)
     }
   } else if (permission.type && (permissionStrategies as any)[permission.type]) {
+    if (config.permission.options && config.permission.options.path) {
+      const req = require
+      config.permission.options.permissions = req(fileUtils.lookupConfRequirePath(config.permission.options.path))
+    }
     PermissionHandlerClass = (permissionStrategies as any)[permission.type]
   } else {
     throw new Error(`Unknown permission type ${permission.type}`)


### PR DESCRIPTION
Valve permissions where not being loaded when server started from script passing options `new DeepstreamServer(options)` neither when passing a `.js` config file in cli.
